### PR TITLE
Synchronize access to @_config only during write

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -48,9 +48,9 @@ module Dry
     #
     # @api public
     def config
+      return @_config if defined?(@_config)
       @_config_mutex.synchronize do
-        return @_config if defined?(@_config)
-        @_config = Config.new(*_settings.keys).new(*_settings.values) unless _settings.empty?
+        @_config ||= Config.new(*_settings.keys).new(*_settings.values) unless _settings.empty?
       end
     end
 


### PR DESCRIPTION
Prior this commit read and write access to `#config` is synchronized.

This commit removes the need of synchronizing when reading an already
initialized @_config.

Writing @_config (typically during boot time) via `configure { ... }`
is still synchronized which "feels safe" (TM).

What do you think? Is "feels safe" good enough for us? :-)

Big pro: Performance improvement!