### PR TITLE
Add processor option to setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.1
   - 2.2
   - rbx-2
-  - jruby
+  - jruby-9.0.5.0
   - ruby-head
   - jruby-head
 env:

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -1,9 +1,27 @@
 module Dry
   module Configurable
     # @private
-    class Config < ::Struct
-      def self.create(hash)
-        self.new(*hash.keys).new(*hash.values)
+    class Config
+      DEFAULT_PROCESSOR = ->(v) { v }.freeze
+
+      def self.create(settings)
+        klass = Class.new(self)
+        klass.__send__(:attr_reader, *settings.map(&:name))
+        settings.each do |setting|
+          klass.__send__(:define_method, "#{setting.name}=") do |value|
+            instance_variable_set(
+              "@#{setting.name}",
+              setting.processor.call(value)
+            )
+          end
+        end
+        klass.new(settings)
+      end
+
+      def initialize(settings)
+        settings.each do |setting|
+          public_send("#{setting.name}=", setting.value) unless setting.none?
+        end
       end
     end
   end

--- a/lib/dry/configurable/config/value.rb
+++ b/lib/dry/configurable/config/value.rb
@@ -1,0 +1,25 @@
+module Dry
+  module Configurable
+    class Config
+      # @private
+      class Value
+        # @private
+        NONE = Object.new.freeze
+
+        attr_reader :name, :processor
+
+        def initialize(name, value, processor)
+          @name, @value, @processor = name, value, processor
+        end
+
+        def value
+          none? ? nil : @value
+        end
+
+        def none?
+          @value.eql?(::Dry::Configurable::Config::Value::NONE)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -1,105 +1,215 @@
 RSpec.shared_examples 'a configurable class' do
   describe Dry::Configurable do
     describe 'settings' do
-      context 'without default value' do
-        before do
-          klass.setting :dsn
-        end
+      context 'without processor option' do
+        context 'without default value' do
+          before do
+            klass.setting :dsn
+          end
 
-        it 'returns nil' do
-          expect(klass.config.dsn).to be(nil)
-        end
-      end
-
-      context 'with default value' do
-        before do
-          klass.setting :dsn, 'sqlite:memory'
-        end
-
-        it 'returns the default value' do
-          expect(klass.config.dsn).to eq('sqlite:memory')
-        end
-      end
-
-      context 'nested configuration' do
-        before do
-          klass.setting :database do
-            setting :dsn, 'sqlite:memory'
+          it 'returns nil' do
+            expect(klass.config.dsn).to be(nil)
           end
         end
 
-        it 'returns the default value' do
-          expect(klass.config.database.dsn).to eq('sqlite:memory')
+        context 'with default value' do
+          before do
+            klass.setting :dsn, 'sqlite:memory'
+          end
+
+          it 'returns the default value' do
+            expect(klass.config.dsn).to eq('sqlite:memory')
+          end
+        end
+
+        context 'nested configuration' do
+          before do
+            klass.setting :database do
+              setting :dsn, 'sqlite:memory'
+            end
+          end
+
+          it 'returns the default value' do
+            expect(klass.config.database.dsn).to eq('sqlite:memory')
+          end
+        end
+      end
+
+      context 'with processor option' do
+        context 'without default value' do
+          before do
+            klass.setting :dsn, processor: ->(dsn) { "sqlite:#{dsn}" }
+          end
+
+          it 'returns nil' do
+            expect(klass.config.dsn).to be(nil)
+          end
+        end
+
+        context 'with default value' do
+          before do
+            klass.setting :dsn, 'memory', processor: ->(dsn) { "sqlite:#{dsn}" }
+          end
+
+          it 'returns the default value' do
+            expect(klass.config.dsn).to eq('sqlite:memory')
+          end
+        end
+
+        context 'nested configuration' do
+          before do
+            klass.setting :database do
+              setting :dsn, 'memory', processor: ->(dsn) { "sqlite:#{dsn}" }
+            end
+          end
+
+          it 'returns the default value' do
+            expect(klass.config.database.dsn).to eq('sqlite:memory')
+          end
         end
       end
     end
 
     describe 'configuration' do
       context 'without nesting' do
-        before do
-          klass.setting :dsn, 'sqlite:memory'
-        end
+        context 'without processor' do
+          before do
+            klass.setting :dsn, 'sqlite:memory'
+          end
 
-        before do
-          klass.configure do |config|
-            config.dsn = 'jdbc:sqlite:memory'
+          before do
+            klass.configure do |config|
+              config.dsn = 'jdbc:sqlite:memory'
+            end
+          end
+
+          it 'updates the config value' do
+            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
           end
         end
 
-        it 'updates the config value' do
-          expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+        context 'with processor' do
+          before do
+            klass.setting :dsn, 'sqlite', processor: ->(dsn) { "#{dsn}:memory"}
+          end
+
+          before do
+            klass.configure do |config|
+              config.dsn = 'jdbc:sqlite'
+            end
+          end
+
+          it 'updates the config value' do
+            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+          end
         end
       end
 
       context 'with nesting' do
-        before do
-          klass.setting :database do
-            setting :dsn, 'sqlite:memory'
+        context 'without processor' do
+          before do
+            klass.setting :database do
+              setting :dsn, 'sqlite:memory'
+            end
+
+            klass.configure do |config|
+              config.database.dsn = 'jdbc:sqlite:memory'
+            end
           end
 
-          klass.configure do |config|
-            config.database.dsn = 'jdbc:sqlite:memory'
+          it 'updates the config value' do
+            expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
           end
         end
 
-        it 'updates the config value' do
-          expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
+        context 'with processor' do
+          before do
+            klass.setting :database do
+              setting :dsn, 'sqlite', processor: ->(dsn) { "#{dsn}:memory"}
+            end
+
+            klass.configure do |config|
+              config.database.dsn = 'jdbc:sqlite'
+            end
+          end
+
+          it 'updates the config value' do
+            expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
+          end
         end
       end
 
       context 'when inherited' do
-        before do
-          klass.setting :dsn
-          klass.configure do |config|
-            config.dsn = 'jdbc:sqlite:memory'
-          end
-        end
-
-        subject!(:subclass) { Class.new(klass) }
-
-        it 'retains its configuration' do
-          expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
-        end
-
-        context 'when the inherited config is modified' do
+        context 'without processor' do
           before do
-            subclass.configure do |config|
-              config.dsn = 'jdbc:sqlite:file'
+            klass.setting :dsn
+            klass.configure do |config|
+              config.dsn = 'jdbc:sqlite:memory'
             end
           end
 
-          it 'does not modify the original' do
-            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+          subject!(:subclass) { Class.new(klass) }
+
+          it 'retains its configuration' do
+            expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
+          end
+
+          context 'when the inherited config is modified' do
+            before do
+              subclass.configure do |config|
+                config.dsn = 'jdbc:sqlite:file'
+              end
+            end
+
+            it 'does not modify the original' do
+              expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+              expect(subclass.config.dsn).to eq('jdbc:sqlite:file')
+            end
+          end
+        end
+
+        context 'with processor' do
+          before do
+            klass.setting :dsn, processor: ->(dsn) { "#{dsn}:memory" }
+            klass.configure do |config|
+              config.dsn = 'jdbc:sqlite'
+            end
+          end
+
+          subject!(:subclass) { Class.new(klass) }
+
+          it 'retains its configuration' do
+            expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
+          end
+
+          context 'when the inherited config is modified' do
+            before do
+              subclass.configure do |config|
+                config.dsn = 'sqlite'
+              end
+            end
+
+            it 'does not modify the original' do
+              expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+              expect(subclass.config.dsn).to eq('sqlite:memory')
+            end
           end
         end
 
         context 'when the inherited settings are modified' do
           before do
+            klass.setting :dsn
+            klass.configure do |config|
+              config.dsn = 'jdbc:sqlite:memory'
+            end
+
             subclass.setting :db
           end
 
+          subject!(:subclass) { Class.new(klass) }
+
           it 'does not modify the original' do
-            expect(klass._settings.keys).to_not include(:db)
+            expect(klass.settings).to_not include(:db)
           end
         end
       end


### PR DESCRIPTION
```ruby
class Foo
  extend Dry::Configurable

  setting :path, 'lib', processor: ->(value) { Pathname(value) }
end

Foo.config.path
# => #<Pathname:lib>

Foo.configure do |config|
  config.path = 'app'
end

Foo.config.path
# => #<Pathname:app>
```