### PR TITLE
Add processor example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class App
   setting :adapter
   
   # Pre-process values
-  setting :path, 'test', processor: ->(value) { Pathname(value) }
+  setting(:path, 'test') { |value| Pathname(value) }
 end
 
 App.configure do |config|

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ class App
     # Can pass a default value
     setting :dsn, 'sqlite:memory'
   end
+  
   # Defaults to nil if no default value is given
   setting :adapter
+  
+  # Pre-process values
+  setting :path, 'test', processor: ->(value) { Pathname(value) }
 end
 
 App.configure do |config|
@@ -33,7 +37,12 @@ end
 
 App.config.database.dsn
 # => 'jdbc:sqlite:memory'
-App.config.adapter # => nil
+
+App.config.adapter
+# => nil
+
+App.config.path
+# => #<Pathname:test>
 ```
 
 ## License


### PR DESCRIPTION
Just adds to the README `processor` option example, discussed in #9 and implemented in #11.

By the way, is there any prevision where a new version will be pushed to rubygems with this feature?

Thanks