### PR TITLE
Allow access to settings through a hash interface

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -17,6 +17,14 @@ module Dry
           end
         end
 
+        klass.__send__(:define_method, '[]') do |name|
+          __send__(name)
+        end
+
+        klass.__send__(:define_method, '[]=') do |name, value|
+          __send__("#{name}=", value)
+        end
+
         klass.new(settings)
       end
 

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -17,14 +17,6 @@ module Dry
           end
         end
 
-        klass.__send__(:define_method, '[]') do |name|
-          __send__(name)
-        end
-
-        klass.__send__(:define_method, '[]=') do |name, value|
-          __send__("#{name}=", value)
-        end
-
         klass.new(settings)
       end
 
@@ -64,6 +56,14 @@ module Dry
         end
       end
       alias to_hash to_h
+
+      def [](name)
+        public_send(name)
+      end
+
+      def []=(name, value)
+        public_send("#{name}=", value)
+      end
     end
   end
 end

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -74,7 +74,7 @@ module Dry
       end
 
       def setting?(name)
-        @config.key?(name)
+        @config.key?(name.to_sym)
       end
     end
   end

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -58,11 +58,23 @@ module Dry
       alias to_hash to_h
 
       def [](name)
+        raise_unknown_setting_error(name) unless setting?(name)
         public_send(name)
       end
 
       def []=(name, value)
+        raise_unknown_setting_error(name) unless setting?(name)
         public_send("#{name}=", value)
+      end
+
+      private
+
+      def raise_unknown_setting_error(name)
+        raise ArgumentError, "+#{name}+ is not a setting name"
+      end
+
+      def setting?(name)
+        @config.key?(name)
       end
     end
   end

--- a/lib/dry/configurable/config/value.rb
+++ b/lib/dry/configurable/config/value.rb
@@ -9,7 +9,7 @@ module Dry
         attr_reader :name, :processor
 
         def initialize(name, value, processor)
-          @name, @value, @processor = name, value, processor
+          @name, @value, @processor = name.to_sym, value, processor
         end
 
         def value

--- a/spec/unit/dry/configurable/config/value_spec.rb
+++ b/spec/unit/dry/configurable/config/value_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Dry::Configurable::Config::Value do
   let(:value) { 'test' }
   let(:processor) { ->(v) { v }}
 
+  describe '#initialize' do
+    it 'coerces string name to symbol' do
+      config = klass.new('db', value, processor)
+
+      expect(config.name).to eq(:db)
+    end
+  end
+
   describe '#name' do
     subject! { config.name }
 

--- a/spec/unit/dry/configurable/config_spec.rb
+++ b/spec/unit/dry/configurable/config_spec.rb
@@ -141,6 +141,10 @@ RSpec.describe Dry::Configurable::Config do
         ArgumentError, '+unknown+ is not a setting name'
       )
     end
+
+    it 'accepts setting name as a string' do
+      expect(config['user']).to eq('root')
+    end
   end
 
   describe '#[]=' do
@@ -160,6 +164,12 @@ RSpec.describe Dry::Configurable::Config do
       expect { config[:unknown] = 'unknown' }.to raise_error(
         ArgumentError, '+unknown+ is not a setting name'
       )
+    end
+
+    it 'accepts setting name as a string' do
+      expect { config['user'] = 'whoami' }.to change(config, :user)
+        .from('root')
+        .to('whoami')
     end
   end
 end

--- a/spec/unit/dry/configurable/config_spec.rb
+++ b/spec/unit/dry/configurable/config_spec.rb
@@ -29,22 +29,6 @@ RSpec.describe Dry::Configurable::Config do
         .from(nil)
         .to('h4xz0rz')
     end
-
-    it 'allows access to settings in the subclass through a hash interface' do
-      expect(config[:db]).to eq('sqlite:memory')
-      expect(config[:user]).to eq('root')
-      expect(config[:pass]).to be(nil)
-
-      expect { config[:db] = 'ineedm0ar' }.to change(config, :db)
-        .from('sqlite:memory')
-        .to('ineedm0ar:memory')
-      expect { config[:user] = 'whoami' }.to change(config, :user)
-        .from('root')
-        .to('whoami')
-      expect { config[:pass] = 'h4xz0rz' }.to change(config, :pass)
-        .from(nil)
-        .to('h4xz0rz')
-    end
   end
 
   describe '#clone' do
@@ -142,6 +126,28 @@ RSpec.describe Dry::Configurable::Config do
           }
         )
       end
+    end
+  end
+
+  describe '#[]' do
+    it 'returns given setting' do
+      expect(config[:db]).to eq('sqlite:memory')
+      expect(config[:user]).to eq('root')
+      expect(config[:pass]).to be(nil)
+    end
+  end
+
+  describe '#[]=' do
+    it 'sets given setting' do
+      expect { config[:db] = 'ineedm0ar' }.to change(config, :db)
+        .from('sqlite:memory')
+        .to('ineedm0ar:memory')
+      expect { config[:user] = 'whoami' }.to change(config, :user)
+        .from('root')
+        .to('whoami')
+      expect { config[:pass] = 'h4xz0rz' }.to change(config, :pass)
+        .from(nil)
+        .to('h4xz0rz')
     end
   end
 end

--- a/spec/unit/dry/configurable/config_spec.rb
+++ b/spec/unit/dry/configurable/config_spec.rb
@@ -135,6 +135,12 @@ RSpec.describe Dry::Configurable::Config do
       expect(config[:user]).to eq('root')
       expect(config[:pass]).to be(nil)
     end
+
+    it 'raises an ArgumentError when setting does not exist' do
+      expect { config[:unknown] }.to raise_error(
+        ArgumentError, '+unknown+ is not a setting name'
+      )
+    end
   end
 
   describe '#[]=' do
@@ -148,6 +154,12 @@ RSpec.describe Dry::Configurable::Config do
       expect { config[:pass] = 'h4xz0rz' }.to change(config, :pass)
         .from(nil)
         .to('h4xz0rz')
+    end
+
+    it 'raises an ArgumentError when setting does not exist' do
+      expect { config[:unknown] = 'unknown' }.to raise_error(
+        ArgumentError, '+unknown+ is not a setting name'
+      )
     end
   end
 end

--- a/spec/unit/dry/configurable/config_spec.rb
+++ b/spec/unit/dry/configurable/config_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe Dry::Configurable::Config do
         .from(nil)
         .to('h4xz0rz')
     end
+
+    it 'allows access to settings in the subclass through a hash interface' do
+      expect(config[:db]).to eq('sqlite:memory')
+      expect(config[:user]).to eq('root')
+      expect(config[:pass]).to be(nil)
+
+      expect { config[:db] = 'ineedm0ar' }.to change(config, :db)
+        .from('sqlite:memory')
+        .to('ineedm0ar:memory')
+      expect { config[:user] = 'whoami' }.to change(config, :user)
+        .from('root')
+        .to('whoami')
+      expect { config[:pass] = 'h4xz0rz' }.to change(config, :pass)
+        .from(nil)
+        .to('h4xz0rz')
+    end
   end
 
   describe '#clone' do


### PR DESCRIPTION
This allows using `#[]` and `#[]=` to get/set settings in the
configuration class.

The idea is that, maybe, it can be useful in order to use the
configuration class as a container for dry-auto_inject (which expects
`#[]` interface) for user configured dependencies.

Also, it facilitates testing when the configuration class is resolved
from a container, because it allows to be easily interchanged with a
hash. Used in this way (but not if the configuration class dependency is
 hardcoded) it could be a replacement for #19 

The code could be refactored and cleaned a little bit extracting to a
method and using `private_class_method`, but I didn't do it because
I don't know what you would prefer. If the PR is accepted and you prefer
having the code refactored in this way I have no inconvenience in changing
it.

Thanks.