### PR TITLE
Add method to reset configuration to default values

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -53,15 +53,6 @@ module Dry
       create_config
     end
 
-    # Resets configuration to default values
-    #
-    # @return [Dry::Configurable::Config]
-    #
-    # @api public
-    def reset_config
-      create_config
-    end
-
     # Return configuration
     #
     # @yield [Dry::Configuration::Config]

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -50,9 +50,16 @@ module Dry
     # @api public
     def config
       return @_config if defined?(@_config)
-      @_config_mutex.synchronize do
-        @_config ||= ::Dry::Configurable::Config.create(_settings) unless _settings.empty?
-      end
+      create_config
+    end
+
+    # Resets configuration to default values
+    #
+    # @return [Dry::Configurable::Config]
+    #
+    # @api public
+    def reset_configuration
+      create_config
     end
 
     # Return configuration
@@ -117,6 +124,13 @@ module Dry
       config_klass = ::Class.new { extend ::Dry::Configurable }
       config_klass.instance_eval(&block)
       config_klass.config
+    end
+
+    # @private
+    def create_config
+      @_config_mutex.synchronize do
+        @_config = ::Dry::Configurable::Config.create(_settings) unless _settings.empty?
+      end
     end
   end
 end

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -58,7 +58,7 @@ module Dry
     # @return [Dry::Configurable::Config]
     #
     # @api public
-    def reset_configuration
+    def reset_config
       create_config
     end
 

--- a/lib/dry/configurable/test_interface.rb
+++ b/lib/dry/configurable/test_interface.rb
@@ -1,0 +1,22 @@
+module Dry
+  module Configurable
+    # Methods meant to be used in a testing scenario
+    module TestInterface
+      # Resets configuration to default values
+      #
+      # @return [Dry::Configurable::Config]
+      #
+      # @api public
+      def reset_config
+        create_config
+      end
+    end
+
+    # Mixes in test interface into the configurable module
+    #
+    # @api public
+    def enable_test_interface
+      extend Dry::Configurable::TestInterface
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
 end
 
 require 'dry/configurable'
+require 'dry/configurable/test_interface'
 
 Dir[Pathname(__FILE__).dirname.join('support/**/*.rb').to_s].each do |file|
   require file

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -243,7 +243,7 @@ RSpec.shared_examples 'a configurable class' do
       end
     end
 
-    describe 'reset_configuration' do
+    describe 'reset_config' do
       before do
         klass.setting :dsn, nil
 
@@ -251,7 +251,7 @@ RSpec.shared_examples 'a configurable class' do
           config.dsn = 'sqlite:memory'
         end
 
-        klass.reset_configuration
+        klass.reset_config
       end
 
       it 'resets configuration to default values' do

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -243,19 +243,23 @@ RSpec.shared_examples 'a configurable class' do
       end
     end
 
-    describe 'reset_config' do
-      before do
-        klass.setting :dsn, nil
+    context 'Test Interface' do
+      before { klass.enable_test_interface }
 
-        klass.configure do |config|
-          config.dsn = 'sqlite:memory'
+      describe 'reset_config' do
+        before do
+          klass.setting :dsn, nil
+
+          klass.configure do |config|
+            config.dsn = 'sqlite:memory'
+          end
+
+          klass.reset_config
         end
 
-        klass.reset_config
-      end
-
-      it 'resets configuration to default values' do
-        expect(klass.config.dsn).to be_nil
+        it 'resets configuration to default values' do
+          expect(klass.config.dsn).to be_nil
+        end
       end
     end
   end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -242,5 +242,21 @@ RSpec.shared_examples 'a configurable class' do
         end
       end
     end
+
+    describe 'reset_configuration' do
+      before do
+        klass.setting :dsn, nil
+
+        klass.configure do |config|
+          config.dsn = 'sqlite:memory'
+        end
+
+        klass.reset_configuration
+      end
+
+      it 'resets configuration to default values' do
+        expect(klass.config.dsn).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Instead of just removing `@_config`, added method eagerly recreates it
when invoked. This is in order to be 'safe' against inspection through
methods non intended to be public (like directly accessing `@_config`).

Please, notice that line:
```
@_config ||= ::Dry::Configurable::Config.create(_settings) unless _settings.empty?
```
has been changed to:
```
@_config = ::Dry::Configurable::Config.create(_settings) unless _settings.empty?
```
so, memoization has been removed. If I'm not wrong, it is still safe and there is no performance lost because `config` method is guarding with:
```
return @_config if defined?(@_config)
```

@solnic in issue #19 you said:
> We can add it as a test-specific interface that people could include on demand

How would you implement it?

Thanks

