### PR TITLE
Raise when setting defined on already configured class

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -1,6 +1,7 @@
 require 'concurrent'
 require 'dry/configurable/config'
 require 'dry/configurable/config/value'
+require 'dry/configurable/error'
 require 'dry/configurable/version'
 
 # A collection of micro-libraries, each intended to encapsulate
@@ -39,7 +40,6 @@ module Dry
     def inherited(subclass)
       subclass.instance_variable_set(:@_config_mutex, ::Mutex.new)
       subclass.instance_variable_set(:@_settings, @_settings.clone)
-      subclass.instance_variable_set(:@_config, @_config.clone) if defined?(@_config)
       super
     end
 
@@ -79,6 +79,11 @@ module Dry
     #
     # @api public
     def setting(key, value = ::Dry::Configurable::Config::Value::NONE, &block)
+      raise(
+        AlreadyConfiguredError,
+        "Cannot add setting `#{key}`, #{self} is already configured"
+      ) if defined?(@_config)
+
       if block
         if block.parameters.empty?
           value = _config_for(&block)

--- a/lib/dry/configurable/error.rb
+++ b/lib/dry/configurable/error.rb
@@ -1,0 +1,8 @@
+# A collection of micro-libraries, each intended to encapsulate
+# a common task in Ruby
+module Dry
+  module Configurable
+    Error = Class.new(::StandardError)
+    AlreadyConfiguredError = ::Class.new(Error)
+  end
+end

--- a/spec/integration/configurable_spec.rb
+++ b/spec/integration/configurable_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe Dry::Configurable do
     let(:klass) do
       Class.new do
         extend Dry::Configurable
+
+        def self.to_s
+          'Test::Configurable'
+        end
       end
     end
 
@@ -13,6 +17,10 @@ RSpec.describe Dry::Configurable do
     let(:base_klass) do
       Class.new do
         extend Dry::Configurable
+
+        def self.to_s
+          'Test::Configurable'
+        end
       end
     end
 


### PR DESCRIPTION
Also removed inheritance of config, this is weird:

```ruby
class Test
  extend Dry::Configurable

  setting :name
end

Test.configure do |config|
  config.name = 'blah'
end

class Test2 < Test; end

Test2.config.name
# => "blah"
```