### PR TITLE
Delegate all NestedConfiguration to its own class to fix reset_config

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -113,9 +113,7 @@ module Dry
 
     # @private
     def _config_for(&block)
-      config_klass = ::Class.new { extend ::Dry::Configurable }
-      config_klass.instance_eval(&block)
-      create_nested_config(config_klass)
+      ::Dry::Configurable::NestedConfig.new(&block)
     end
 
     # @private
@@ -134,11 +132,6 @@ module Dry
     # @private
     def nested_configs
       _settings.select { |setting| setting.value.kind_of?(::Dry::Configurable::NestedConfig) }.map(&:value)
-    end
-
-    # @private
-    def create_nested_config(klass)
-      ::Dry::Configurable::NestedConfig.new(klass)
     end
   end
 end

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -1,5 +1,6 @@
 require 'concurrent'
 require 'dry/configurable/config'
+require 'dry/configurable/nested_config'
 require 'dry/configurable/config/value'
 require 'dry/configurable/version'
 
@@ -114,14 +115,30 @@ module Dry
     def _config_for(&block)
       config_klass = ::Class.new { extend ::Dry::Configurable }
       config_klass.instance_eval(&block)
-      config_klass.config
+      create_nested_config(config_klass)
     end
 
     # @private
     def create_config
       @_config_mutex.synchronize do
+        create_config_for_nested_configurations
         @_config = ::Dry::Configurable::Config.create(_settings) unless _settings.empty?
       end
+    end
+
+    # @private
+    def create_config_for_nested_configurations
+      nested_configs.map {  |nested_config| nested_config.create_config }
+    end
+
+    # @private
+    def nested_configs
+      _settings.select { |setting| setting.value.kind_of?(::Dry::Configurable::NestedConfig) }.map(&:value)
+    end
+
+    # @private
+    def create_nested_config(klass)
+      ::Dry::Configurable::NestedConfig.new(klass)
     end
   end
 end

--- a/lib/dry/configurable/nested_config.rb
+++ b/lib/dry/configurable/nested_config.rb
@@ -1,0 +1,31 @@
+module Dry
+  module Configurable
+    # @private
+    class NestedConfig
+      def initialize(klass)
+        @klass = klass
+      end
+
+        # @private no, really...
+      def create_config
+        if @klass.instance_variables.include?(:@_config)
+          @klass.__send__(:create_config)
+        end
+      end
+
+      private
+
+      def config
+        @klass.config
+      end
+
+      def method_missing(method, *args, &block)
+        config.respond_to?(method) ? config.public_send(method, *args, &block) : super
+      end
+
+      def respond_to_missing?(method, _include_private = false)
+        config.respond_to?(method) || super
+      end
+    end
+  end
+end

--- a/lib/dry/configurable/nested_config.rb
+++ b/lib/dry/configurable/nested_config.rb
@@ -2,7 +2,9 @@ module Dry
   module Configurable
     # @private
     class NestedConfig
-      def initialize(klass)
+      def initialize(&block)
+        klass = ::Class.new { extend ::Dry::Configurable }
+        klass.instance_eval(&block)
         @klass = klass
       end
 


### PR DESCRIPTION
Regarding the commit https://github.com/dry-rb/dry-configurable/commit/fd8ccfe68aaa5207f0e543b1cc3f92b54d51c5cf where it exposes that `reset_config` was not working for nested configurations.

@AMHOL I have followed what we talked yesterday, and even it since a little by hacky as well, all the logic for nested configurations is encapsulated in its own class.

The PR still in WIP because I wanted to know if you like this approach if so I will add a test for everything that is new and remove the WIP label so we can merge it, if not I will keep looking for an alternative.

@AMHOL thanks for the help.