### PR TITLE
Raise exception for alreday created configs

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -139,7 +139,7 @@ module Dry
     # @private
     def raise_already_defined_config(key)
       raise AlreadyDefinedConfig,
-        "Cannot add setting `#{key}`, #{self} is already configured"
+        "Cannot add setting +#{key}+, #{self} is already configured"
     end
   end
 end

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -1,5 +1,6 @@
 require 'concurrent'
 require 'dry/configurable/config'
+require 'dry/configurable/error'
 require 'dry/configurable/nested_config'
 require 'dry/configurable/config/value'
 require 'dry/configurable/version'
@@ -80,6 +81,7 @@ module Dry
     #
     # @api public
     def setting(key, value = ::Dry::Configurable::Config::Value::NONE, &block)
+      raise_already_defined_config(key) if defined?(@_config)
       if block
         if block.parameters.empty?
           value = _config_for(&block)
@@ -132,6 +134,12 @@ module Dry
     # @private
     def nested_configs
       _settings.select { |setting| setting.value.kind_of?(::Dry::Configurable::NestedConfig) }.map(&:value)
+    end
+
+    # @private
+    def raise_already_defined_config(key)
+      raise AlreadyDefinedConfig,
+        "Cannot add setting `#{key}`, #{self} is already configured"
     end
   end
 end

--- a/lib/dry/configurable/error.rb
+++ b/lib/dry/configurable/error.rb
@@ -1,0 +1,8 @@
+# A collection of micro-libraries, each intended to encapsulate
+# a common task in Ruby
+module Dry
+ module Configurable
+   Error = Class.new(::StandardError)
+   AlreadyDefinedConfig = ::Class.new(Error)
+ end
+end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -224,9 +224,10 @@ RSpec.shared_examples 'a configurable class' do
           end
         end
 
-        context 'when the inherited settings are modified ' do
+        context 'when the inherited settings are modified' do
           before do
             klass.setting :dsn
+            subclass.setting :db
             klass.configure do |config|
               config.dsn = 'jdbc:sqlite:memory'
             end
@@ -234,10 +235,8 @@ RSpec.shared_examples 'a configurable class' do
 
           subject!(:subclass) { Class.new(klass) }
 
-          it 'raise an Exception' do
-            expect{ subclass.setting :db }.to raise_error(
-              Dry::Configurable::AlreadyDefinedConfig
-            )
+          it 'does not modify the original' do
+            expect(klass.settings).to_not include(:db)
           end
         end
       end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -224,20 +224,20 @@ RSpec.shared_examples 'a configurable class' do
           end
         end
 
-        context 'when the inherited settings are modified' do
+        context 'when the inherited settings are modified ' do
           before do
             klass.setting :dsn
             klass.configure do |config|
               config.dsn = 'jdbc:sqlite:memory'
             end
-
-            subclass.setting :db
           end
 
           subject!(:subclass) { Class.new(klass) }
 
-          it 'does not modify the original' do
-            expect(klass.settings).to_not include(:db)
+          it 'raise an Exception' do
+            expect{ subclass.setting :db }.to raise_error(
+              Dry::Configurable::AlreadyDefinedConfig
+            )
           end
         end
       end
@@ -265,6 +265,19 @@ RSpec.shared_examples 'a configurable class' do
           expect(klass.config.dsn).to be_nil
           expect(klass.config.pool.size).to be_nil
         end
+      end
+    end
+
+    context 'Try to set new value after config has been created' do
+      before do
+        klass.setting :dsn, 'sqlite:memory'
+        klass.config
+      end
+
+      it 'raise an exception' do
+        expect{ klass.setting :pool, 5 }.to raise_error(
+          Dry::Configurable::AlreadyDefinedConfig
+        )
       end
     end
   end


### PR DESCRIPTION
#30 

@AMHOL raise an exception when try to set a new configuration after `create_config` has been called.

I saw in the closed pull request there was one with a similar description, so I continue with the error definition style you had in mind, hope you like it 😄.

Also, I had to modify some tests in order to make it pass regarding when inheriting. 