### PR TITLE
Add reader option to create accessor method at the class level

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ class App
   # Defaults to nil if no default value is given
   setting :adapter
   # Passing the reader option as true will create reader method for the class
-  setting :pool, 5 , reader: true
+  setting :pool, 5 ,reader: true
   # Passing the reader attributes works with nested configuration
-  setting :uploader, nil, reader: true do
+  setting :uploader ,reader: true do
     setting :bucket, 'dev'
   end
 end

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ class App
   end
   # Defaults to nil if no default value is given
   setting :adapter
+  # Passing the reader option as true will create reader method for the class
+  setting :pool, 5 , reader: true
+  # Passing the reader attributes works with nested configuration
+  setting :uploader, nil, reader: true do
+    setting :bucket, 'dev'
+  end
 end
 
 App.configure do |config|
@@ -34,6 +40,8 @@ end
 App.config.database.dsn
 # => 'jdbc:sqlite:memory'
 App.config.adapter # => nil
+App.pool # => 5
+App.uploader.bucket # => 'dev'
 ```
 
 ## Links

--- a/lib/dry/configurable/argument_parser.rb
+++ b/lib/dry/configurable/argument_parser.rb
@@ -1,0 +1,92 @@
+module Dry
+  # Argument parser
+  #
+  # Passing and array or arguments, it will decide wich one are arguments
+  # and which one are options.
+  #
+  # We have a limitation if setting the value without options, as a hash
+  # having the same key as one of the valid options, will parse the value
+  # as options.
+  #
+  # @example
+  #   p = Dry::Configurable::ArgumentParser.new(['db:sqlite', { reader: true })
+  #
+  #   p.value # => 'db:sqlite'
+  #   p.options # => { reader: true }
+  #
+  #   Dry::Configurable::ArgumentParser.call(['db:sqlite', { reader: true })
+  #    # => [ 'db:sqlite', { reader: true } ]
+
+  module Configurable
+    # @private
+    class ArgumentParser
+      VALID_OPTIONS = %i(reader)
+
+      def self.call(data)
+        parsed = new(data)
+        [ parsed.value, parsed.options ]
+      end
+
+      def initialize(data)
+        @data = data
+      end
+
+      def value
+        parse_args[:value]
+      end
+
+      def options
+        parse_args[:options]
+      end
+
+      private
+
+      attr_reader :data
+
+      # @private
+      def default_args
+        { value: nil, options: {} }
+      end
+
+      # @private
+      def parse_args
+        return default_args if data.empty?
+        if data.size > 1
+          { value: data.first, options: check_options(data.last) }
+        else
+          default_args.merge(check_for_value_or_options(data.first))
+        end
+      end
+
+      # @private
+      def check_options(opts)
+        return {} if opts.empty?
+        opts.select { |k, _| VALID_OPTIONS.include?(k) }
+      end
+
+      # @private
+      def check_for_value_or_options(args)
+        case args
+        when Hash
+          parse_hash(args)
+        else
+          { value: args }
+        end
+      end
+
+      # @private
+      def parse_hash(args)
+        if hash_include_options_key(args)
+          { options: check_options(args) }
+        else
+          { value: args }
+        end
+      end
+
+      # @private
+      def hash_include_options_key(hash)
+        hash.any?{ |k, _| VALID_OPTIONS.include?(k) }
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -48,6 +48,80 @@ RSpec.shared_examples 'a configurable class' do
               )
             end
           end
+
+          context 'reader option' do
+            context 'without passing option' do
+              before do
+                klass.setting :dsn, nil
+              end
+
+              before do
+                klass.configure do |config|
+                  config.dsn = 'jdbc:sqlite:memory'
+                end
+              end
+
+              it 'will not create a getter method' do
+                expect(klass.respond_to?(:dsn)).to be_falsey
+              end
+            end
+
+            context 'with hash as value ' do
+              before do
+                klass.setting :dsn, {foo: 'bar'}, reader: true
+              end
+
+              it 'will create a getter method' do
+                expect(klass.dsn).to eq({foo: 'bar'})
+                expect(klass.respond_to?(:dsn)).to be_truthy
+              end
+            end
+
+            context 'with option set to true' do
+              before do
+                klass.setting :dsn, 'testing', reader: true
+              end
+
+              it 'will create a getter method' do
+                expect(klass.dsn).to eq 'testing'
+                expect(klass.respond_to?(:dsn)).to be_truthy
+              end
+            end
+
+            context 'with nested configuration' do
+              before do
+                klass.setting :dsn, nil, reader: true do
+                  setting :pool, 5
+                end
+              end
+
+              it 'will create a nested getter method' do
+                expect(klass.dsn.pool).to eq 5
+              end
+            end
+
+            context 'with processor' do
+              context 'with default value' do
+                before do
+                  klass.setting(:dsn, 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
+                end
+
+                it 'returns the default value' do
+                  expect(klass.dsn).to eq('sqlite:memory')
+                end
+              end
+
+              context 'without default value' do
+                before do
+                  klass.setting(:dsn, nil, reader: true) { |dsn| "sqlite:#{dsn}" }
+                end
+
+                xit 'returns the default value' do
+                  expect(klass.dsn).to eq(nil)
+                end
+              end
+            end
+          end
         end
 
         context 'nested configuration' do

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -116,7 +116,7 @@ RSpec.shared_examples 'a configurable class' do
                   klass.setting(:dsn, nil, reader: true) { |dsn| "sqlite:#{dsn}" }
                 end
 
-                xit 'returns the default value' do
+                it 'returns the default value' do
                   expect(klass.dsn).to eq(nil)
                 end
               end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -48,77 +48,77 @@ RSpec.shared_examples 'a configurable class' do
               )
             end
           end
+        end
 
-          context 'reader option' do
-            context 'without passing option' do
-              before do
-                klass.setting :dsn, nil
-              end
+        context 'reader option' do
+          context 'without passing option' do
+            before do
+              klass.setting :dsn
+            end
 
-              before do
-                klass.configure do |config|
-                  config.dsn = 'jdbc:sqlite:memory'
-                end
-              end
-
-              it 'will not create a getter method' do
-                expect(klass.respond_to?(:dsn)).to be_falsey
+            before do
+              klass.configure do |config|
+                config.dsn = 'jdbc:sqlite:memory'
               end
             end
 
-            context 'with hash as value ' do
-              before do
-                klass.setting :dsn, {foo: 'bar'}, reader: true
-              end
+            it 'will not create a getter method' do
+              expect(klass.respond_to?(:dsn)).to be_falsey
+            end
+          end
 
-              it 'will create a getter method' do
-                expect(klass.dsn).to eq({foo: 'bar'})
-                expect(klass.respond_to?(:dsn)).to be_truthy
+          context 'with hash as value ' do
+            before do
+              klass.setting :dsn, {foo: 'bar'}, reader: true
+            end
+
+            it 'will create a getter method' do
+              expect(klass.dsn).to eq({foo: 'bar'})
+              expect(klass.respond_to?(:dsn)).to be_truthy
+            end
+          end
+
+          context 'with option set to true' do
+            before do
+              klass.setting :dsn, 'testing', reader: true
+            end
+
+            it 'will create a getter method' do
+              expect(klass.dsn).to eq 'testing'
+              expect(klass.respond_to?(:dsn)).to be_truthy
+            end
+          end
+
+          context 'with nested configuration' do
+            before do
+              klass.setting :dsn, reader: true do
+                setting :pool, 5
               end
             end
 
-            context 'with option set to true' do
+            it 'will create a nested getter method' do
+              expect(klass.dsn.pool).to eq 5
+            end
+          end
+
+          context 'with processor' do
+            context 'with default value' do
               before do
-                klass.setting :dsn, 'testing', reader: true
+                klass.setting(:dsn, 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
               end
 
-              it 'will create a getter method' do
-                expect(klass.dsn).to eq 'testing'
-                expect(klass.respond_to?(:dsn)).to be_truthy
+              it 'returns the default value' do
+                expect(klass.dsn).to eq('sqlite:memory')
               end
             end
 
-            context 'with nested configuration' do
+            context 'without default value' do
               before do
-                klass.setting :dsn, nil, reader: true do
-                  setting :pool, 5
-                end
+                klass.setting(:dsn, reader: true) { |dsn| "sqlite:#{dsn}" }
               end
 
-              it 'will create a nested getter method' do
-                expect(klass.dsn.pool).to eq 5
-              end
-            end
-
-            context 'with processor' do
-              context 'with default value' do
-                before do
-                  klass.setting(:dsn, 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
-                end
-
-                it 'returns the default value' do
-                  expect(klass.dsn).to eq('sqlite:memory')
-                end
-              end
-
-              context 'without default value' do
-                before do
-                  klass.setting(:dsn, nil, reader: true) { |dsn| "sqlite:#{dsn}" }
-                end
-
-                it 'returns the default value' do
-                  expect(klass.dsn).to eq(nil)
-                end
+              it 'returns the default value' do
+                expect(klass.dsn).to eq(nil)
               end
             end
           end

--- a/spec/unit/dry/configurable/argument_parser_spec.rb
+++ b/spec/unit/dry/configurable/argument_parser_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe Dry::Configurable::ArgumentParser do
+  let(:klass) { Dry::Configurable::ArgumentParser }
+  context 'with no args' do
+    let(:parsed) { klass.new([]) }
+
+    it 'return default values' do
+      expect(parsed.value).to eq nil
+      expect(parsed.options).to eq ({ })
+    end
+  end
+
+  context 'with value and options' do
+    let(:parsed) { klass.new([value, options]) }
+
+    context 'valid options' do
+      let(:value) { 'dry-rb' }
+      let(:options) do
+        { reader: true }
+      end
+
+      it 'returns correct value and options' do
+        expect(parsed.value).to eq 'dry-rb'
+        expect(parsed.options).to eq ({ reader: true })
+      end
+    end
+
+    context 'invalid options' do
+      let(:value) { 'dry-rb' }
+      let(:options) do
+        { writer: true }
+      end
+
+      it 'returns correct values and empty options' do
+        expect(parsed.value).to eq 'dry-rb'
+        expect(parsed.options).to eq ({ })
+      end
+    end
+
+    context 'values as hash' do
+      let(:value) do
+        { db: 'dry-rb'  }
+      end
+      let(:options) do
+        { reader: true }
+      end
+
+      it 'returns correct values and empty options' do
+        expect(parsed.value).to eq ({ db: 'dry-rb'  })
+        expect(parsed.options).to eq ({ reader: true })
+      end
+    end
+
+    context 'values as array' do
+      let(:value) { [1,2,3] }
+      let(:options) do
+        { reader: true }
+      end
+
+      it 'returns correct values and empty options' do
+        expect(parsed.value).to eq ([1,2,3])
+        expect(parsed.options).to eq ({ reader: true })
+      end
+    end
+  end
+
+  context 'with value only' do
+    let(:parsed) { klass.new([value]) }
+    context 'valid options' do
+      let(:value) { 'dry-rb' }
+
+      it 'returns correct value and options' do
+        expect(parsed.value).to eq 'dry-rb'
+        expect(parsed.options).to eq ({ })
+      end
+    end
+
+    context 'with hash with non option key' do
+      let(:value) do
+        { writer: true }
+      end
+
+      it 'returns correct value and options' do
+        expect(parsed.value).to eq ({ writer: true })
+        expect(parsed.options).to eq ({})
+      end
+    end
+
+    context 'with hash with option key' do
+      let(:value) do
+        { reader: true, writer: true }
+      end
+
+      it 'returns correct value and options' do
+        expect(parsed.value).to eq nil
+        expect(parsed.options).to eq ({ reader: true })
+      end
+    end
+  end
+
+  context 'with options only' do
+    let(:parsed) { klass.new([options]) }
+    context 'valid options' do
+      let(:options) do
+        { reader: true }
+      end
+
+      it 'returns correct value and options' do
+        expect(parsed.value).to eq nil
+        expect(parsed.options).to eq ({ reader: true })
+      end
+    end
+  end
+end


### PR DESCRIPTION
#8 #25 

Since the change for accepting `Dry::Types` looks a little big, I thought about dividing the task in different pull requests.
With this experiment, I used the `method_missing` to create the reader method, at first I use `define_method` but it was more verbose.

One thing I found with this solution, is that for `setting` with a `block` you have to pass the default value even if it is `nil`
```ruby
klass.setting(:dsn, 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
klass.dsn # => 'sqlite:memory'

klass.setting(:dsn, nil, reader: true) { |dsn| "sqlite:#{dsn}" }
klass.dsn # => 'sqlite:'
```
Because with the definition of `setting`
```ruby
def setting(key, value = ::Dry::Configurable::Config::Value::NONE, options = {}, &block)
```
the second argument always is going to be the value.
We could use `keyword` arguments like:
```ruby
def setting(key, value: ::Dry::Configurable::Config::Value::NONE, reader: false, &block)

klass.setting(:dsn, reader: true) {|dsn| "sqlite:#{dsn}" }
klass.dsn #=> nil

klass.setting(:dsn, value: 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
klass.dsn # => 'sqlite:memory'
```

But this will break the public api, I want to know your opinion first.
P.D I left a skipping test, that shows the behavior described above.
@solnic @AMHOL 

