### PR TITLE
Recurse nested configs to convert to hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## Fixed
 
 * Allow for boolean false as default setting value ([yuszuv](https://github.com/yuszuv))
+* Convert nested configs to nested hashes with `Config#to_h` ([saverio-kantox](https://github.com/saverio-kantox))
 
 [Compare v0.6.2...HEAD](https://github.com/dry-rb/dry-configurable/compare/v0.6.2...HEAD)

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -48,7 +48,8 @@ module Dry
         @config.each_with_object({}) do |tuple, hash|
           key, value = tuple
 
-          if value.is_a?(::Dry::Configurable::Config)
+          case value
+          when ::Dry::Configurable::Config, ::Dry::Configurable::NestedConfig
             hash[key] = value.to_h
           else
             hash[key] = value

--- a/spec/unit/dry/configurable/config_spec.rb
+++ b/spec/unit/dry/configurable/config_spec.rb
@@ -68,7 +68,9 @@ RSpec.describe Dry::Configurable::Config do
 
     context 'with nesting' do
       let(:nested_setting) do
-        klass.create([value_class.new(:bar, 'baz', ->(v) { v })])
+        ::Dry::Configurable::NestedConfig.new do
+          setting(:bar, 'baz') { |v| v }
+        end.tap(&:create_config)
       end
       let(:settings) do
         [


### PR DESCRIPTION
Nested configs are not instances of `Config` so the `to_h` method fails to recurse into them.

This simple change will enable to recurse into them and return all the nested values.