### PR TITLE
Depend on `dry-struct` gem

### DIFF
--- a/dry-configurable.gemspec
+++ b/dry-configurable.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_dependency 'dry-core', '~> 0.4', '>= 0.4.4'
+  spec.add_dependency 'dry-struct', '~> 0.5'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes `LoadError`.
See https://github.com/dry-rb/dry-configurable/commit/1caa28e3b405db806aaf1dc09748e1213ec9bd08#r29914373