### PR TITLE
[WIP] Instance-level configuration

### DIFF
--- a/dry-configurable.gemspec
+++ b/dry-configurable.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.7'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -4,7 +4,7 @@ module Dry
   module Configurable
     # @private
     class Config
-      DEFAULT_PROCESSOR = ->(v) { v }.freeze
+      DEFAULT_PROCESSOR = -> (v) { v }.freeze
 
       def self.create(settings)
         klass = ::Class.new(self)
@@ -27,10 +27,16 @@ module Dry
         @config = ::Concurrent::Hash.new
 
         settings.each do |setting|
-          if setting.none?
+          if setting.undefined?
             @config[setting.name] = nil
           else
-            public_send("#{setting.name}=", setting.value)
+            if setting.nested_config?
+              value = setting.value.create_config
+            else
+              value = setting.value
+            end
+
+            public_send("#{setting.name}=", value)
           end
         end
       end

--- a/lib/dry/configurable/config/value.rb
+++ b/lib/dry/configurable/config/value.rb
@@ -3,9 +3,6 @@ module Dry
     class Config
       # @private
       class Value
-        # @private
-        NONE = ::Object.new.freeze
-
         attr_reader :name, :processor
 
         def initialize(name, value, processor)
@@ -15,11 +12,15 @@ module Dry
         end
 
         def value
-          none? ? nil : @value
+          Undefined.default(@value, nil)
         end
 
-        def none?
-          @value.equal?(::Dry::Configurable::Config::Value::NONE)
+        def undefined?
+          Undefined.eql?(@value)
+        end
+
+        def nested_config?
+          @value.is_a?(::Dry::Configurable::NestedConfig)
         end
       end
     end

--- a/lib/dry/configurable/nested_config.rb
+++ b/lib/dry/configurable/nested_config.rb
@@ -3,23 +3,17 @@ module Dry
     # @private
     class NestedConfig
       def initialize(&block)
-        klass = ::Class.new { extend ::Dry::Configurable }
-        klass.instance_eval(&block)
-        @klass = klass
+        @definition = block
       end
 
       # @private no, really...
       def create_config
-        if @klass.instance_variables.include?(:@_config)
-          @klass.__send__(:create_config)
-        end
+        klass = ::Class.new { extend ::Dry::Configurable }
+        klass.instance_exec(&@definition)
+        klass.config
       end
 
       private
-
-      def config
-        @klass.config
-      end
 
       def method_missing(method, *args, &block)
         config.respond_to?(method) ? config.public_send(method, *args, &block) : super

--- a/lib/dry/configurable/test_interface.rb
+++ b/lib/dry/configurable/test_interface.rb
@@ -8,6 +8,8 @@ module Dry
       #
       # @api public
       def reset_config
+        remove_instance_variable(:@config)
+
         create_config
       end
     end

--- a/spec/integration/configurable_spec.rb
+++ b/spec/integration/configurable_spec.rb
@@ -22,4 +22,25 @@ RSpec.describe Dry::Configurable do
 
     it_behaves_like 'a configurable class'
   end
+
+  context 'when included' do
+    let(:klass) do
+      Class.new do
+        include Dry::Configurable
+      end
+    end
+
+    describe 'shallow config' do
+      before do
+        klass.setting :dsn
+      end
+
+      it 'allows to configure class instances' do
+        obj = klass.new
+        expect(obj.config.dsn).to be_nil
+        obj.config.dsn = 'jdbc:sqlite:memory'
+        expect(obj.config.dsn).to eql('jdbc:sqlite:memory')
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -1,367 +1,342 @@
 RSpec.shared_examples 'a configurable class' do
-  describe Dry::Configurable do
-    describe 'settings' do
-      context 'without processor option' do
-        context 'without default value' do
-          before do
-            klass.setting :dsn
-          end
+  describe 'settings' do
+    context 'without default value' do
+      before { klass.setting :dsn }
 
-          it 'returns nil' do
-            expect(klass.config.dsn).to be(nil)
+      it 'returns nil' do
+        expect(klass.config.dsn).to be(nil)
+      end
+    end
+
+    context 'with a nil default value' do
+      before { klass.setting :dsn, nil }
+
+      it 'returns the default value' do
+        expect(klass.config.dsn).to be(nil)
+      end
+    end
+
+    context 'with a false default value' do
+      before { klass.setting :dsn, false }
+
+      it 'returns the default value' do
+        expect(klass.config.dsn).to be(false)
+      end
+    end
+
+    context 'with a string default value' do
+      before { klass.setting :dsn, 'sqlite:memory' }
+
+      it 'returns the default value' do
+        expect(klass.config.dsn).to eq('sqlite:memory')
+      end
+    end
+
+    context 'with a hash default value' do
+      before do
+        klass.setting :db_config, {
+          user: 'root',
+          password: ''
+        }
+      end
+
+      it 'returns the default value' do
+        expect(klass.config.db_config).to eq(
+          user: 'root',
+          password: ''
+        )
+      end
+    end
+
+    context 'reader option' do
+      context 'without passing option' do
+        before { klass.setting :dsn }
+        before { klass.config.dsn = 'jdbc:sqlite:memory' }
+
+        it 'will not create a getter method' do
+          expect(klass).not_to respond_to(:dsn)
+        end
+      end
+
+      context 'with hash as value ' do
+        before { klass.setting :dsn, { foo: 'bar' }, reader: true }
+
+        it 'will create a getter method' do
+          expect(klass.dsn).to eq(foo: 'bar')
+          expect(klass).to respond_to(:dsn)
+        end
+      end
+
+      context 'with option set to true' do
+        before { klass.setting :dsn, 'testing', reader: true }
+
+        it 'will create a getter method' do
+          expect(klass.dsn).to eq 'testing'
+          expect(klass).to respond_to(:dsn)
+        end
+      end
+
+      context 'with nested configuration' do
+        before do
+          klass.setting :dsn, reader: true do
+            setting :pool, 5
           end
         end
 
+        it 'will create a nested getter method' do
+          expect(klass.dsn.pool).to eq 5
+        end
+      end
+
+      context 'with processor' do
         context 'with default value' do
-          context 'with a nil default value' do
-            before do
-              klass.setting :dsn, nil
-            end
-
-            it 'returns the default value' do
-              expect(klass.config.dsn).to be(nil)
-            end
-          end
-
-          context 'with a false default value' do
-            before do
-              klass.setting :dsn, false
-            end
-
-            it 'returns the default value' do
-              expect(klass.config.dsn).to be(false)
-            end
-          end
-
-          context 'with a string default value' do
-            before do
-              klass.setting :dsn, 'sqlite:memory'
-            end
-
-            it 'returns the default value' do
-              expect(klass.config.dsn).to eq('sqlite:memory')
-            end
-          end
-
-          context 'with a hash default value' do
-            before do
-              klass.setting :db_config, {
-                user: 'root',
-                password: ''
-              }
-            end
-
-            it 'returns the default value' do
-              expect(klass.config.db_config).to eq(
-                user: 'root',
-                password: ''
-              )
-            end
-          end
-        end
-
-        context 'reader option' do
-          context 'without passing option' do
-            before do
-              klass.setting :dsn
-            end
-
-            before do
-              klass.configure do |config|
-                config.dsn = 'jdbc:sqlite:memory'
-              end
-            end
-
-            it 'will not create a getter method' do
-              expect(klass.respond_to?(:dsn)).to be_falsey
-            end
-          end
-
-          context 'with hash as value ' do
-            before do
-              klass.setting :dsn, { foo: 'bar' }, reader: true
-            end
-
-            it 'will create a getter method' do
-              expect(klass.dsn).to eq(foo: 'bar')
-              expect(klass.respond_to?(:dsn)).to be_truthy
-            end
-          end
-
-          context 'with option set to true' do
-            before do
-              klass.setting :dsn, 'testing', reader: true
-            end
-
-            it 'will create a getter method' do
-              expect(klass.dsn).to eq 'testing'
-              expect(klass.respond_to?(:dsn)).to be_truthy
-            end
-          end
-
-          context 'with nested configuration' do
-            before do
-              klass.setting :dsn, reader: true do
-                setting :pool, 5
-              end
-            end
-
-            it 'will create a nested getter method' do
-              expect(klass.dsn.pool).to eq 5
-            end
-          end
-
-          context 'with processor' do
-            context 'with default value' do
-              before do
-                klass.setting(:dsn, 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
-              end
-
-              it 'returns the default value' do
-                expect(klass.dsn).to eq('sqlite:memory')
-              end
-            end
-
-            context 'without default value' do
-              before do
-                klass.setting(:dsn, reader: true) { |dsn| "sqlite:#{dsn}" }
-              end
-
-              it 'returns the default value' do
-                expect(klass.dsn).to eq(nil)
-              end
-            end
-          end
-        end
-
-        context 'nested configuration' do
           before do
-            klass.setting :database do
-              setting :dsn, 'sqlite:memory'
-            end
+            klass.setting(:dsn, 'memory', reader: true) { |dsn| "sqlite:#{dsn}" }
           end
 
           it 'returns the default value' do
-            expect(klass.config.database.dsn).to eq('sqlite:memory')
+            expect(klass.dsn).to eq('sqlite:memory')
+          end
+        end
+
+        context 'without default value' do
+          before do
+            klass.setting(:dsn, reader: true) { |dsn| "sqlite:#{dsn}" }
+          end
+
+          it 'returns the default value' do
+            expect(klass.dsn).to eq(nil)
+          end
+        end
+      end
+    end
+
+    context 'nested configuration' do
+      before do
+        klass.setting :database do
+          setting :dsn, 'sqlite:memory'
+        end
+      end
+
+      it 'returns the default value' do
+        expect(klass.config.database.dsn).to eq('sqlite:memory')
+      end
+    end
+
+    context 'with processor' do
+      context 'without default value' do
+        before do
+          klass.setting(:dsn) { |dsn| "sqlite:#{dsn}" }
+        end
+
+        it 'returns nil' do
+          expect(klass.config.dsn).to be(nil)
+        end
+      end
+
+      context 'with default value' do
+        before do
+          klass.setting(:dsn, 'memory') { |dsn| "sqlite:#{dsn}" }
+        end
+
+        it 'returns the default value' do
+          expect(klass.config.dsn).to eq('sqlite:memory')
+        end
+      end
+
+      context 'nested configuration' do
+        before do
+          klass.setting :database do
+            setting(:dsn, 'memory') { |dsn| "sqlite:#{dsn}" }
+          end
+        end
+
+        it 'returns the default value' do
+          expect(klass.config.database.dsn).to eq('sqlite:memory')
+        end
+      end
+    end
+  end
+
+  describe 'configuration' do
+    context 'without nesting' do
+      context 'without processor' do
+        before do
+          klass.setting :dsn, 'sqlite:memory'
+        end
+
+        before do
+          klass.config.dsn = 'jdbc:sqlite:memory'
+        end
+
+        it 'updates the config value' do
+          expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+        end
+      end
+
+      context 'with processor' do
+        before do
+          klass.setting(:dsn, 'sqlite') { |dsn| "#{dsn}:memory" }
+        end
+
+        before do
+          klass.config.dsn = 'jdbc:sqlite'
+        end
+
+        it 'updates the config value' do
+          expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+        end
+      end
+    end
+
+    context 'with nesting' do
+      context 'without processor' do
+        before do
+          klass.setting :database do
+            setting :dsn, 'sqlite:memory'
+          end
+
+          klass.config.database.dsn = 'jdbc:sqlite:memory'
+        end
+
+        it 'updates the config value' do
+          expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
+        end
+      end
+
+      context 'with processor' do
+        before do
+          klass.setting :database do
+            setting(:dsn, 'sqlite') { |dsn| "#{dsn}:memory" }
+          end
+
+          klass.config.database.dsn = 'jdbc:sqlite'
+        end
+
+        it 'updates the config value' do
+          expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
+        end
+      end
+    end
+
+    context 'when finalized' do
+      before do
+        klass.setting :dsn
+        klass.config.dsn = 'jdbc:sqlite'
+        klass.finalize!
+      end
+
+      it 'disallows modification' do
+        expect do
+          klass.config.dsn = 'jdbc:sqlite'
+        end.to raise_error(Dry::Configurable::FrozenConfig, 'Cannot modify frozen config')
+      end
+
+      it 'disallows direct modification on config' do
+        expect do
+          klass.config.dsn = 'jdbc:sqlite:memory'
+        end.to raise_error(Dry::Configurable::FrozenConfig, 'Cannot modify frozen config')
+      end
+    end
+
+    context 'when inherited' do
+      context 'without processor' do
+        before do
+          klass.setting :dsn
+          klass.config.dsn = 'jdbc:sqlite:memory'
+        end
+
+        subject!(:subclass) { Class.new(klass) }
+
+        it 'retains its configuration' do
+          expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
+        end
+
+        context 'when the inherited config is modified' do
+          before do
+            subclass.config.dsn = 'jdbc:sqlite:file'
+          end
+
+          it 'does not modify the original' do
+            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+            expect(subclass.config.dsn).to eq('jdbc:sqlite:file')
           end
         end
       end
 
       context 'with processor' do
-        context 'without default value' do
-          before do
-            klass.setting(:dsn) { |dsn| "sqlite:#{dsn}" }
-          end
-
-          it 'returns nil' do
-            expect(klass.config.dsn).to be(nil)
-          end
-        end
-
-        context 'with default value' do
-          before do
-            klass.setting(:dsn, 'memory') { |dsn| "sqlite:#{dsn}" }
-          end
-
-          it 'returns the default value' do
-            expect(klass.config.dsn).to eq('sqlite:memory')
-          end
-        end
-
-        context 'nested configuration' do
-          before do
-            klass.setting :database do
-              setting(:dsn, 'memory') { |dsn| "sqlite:#{dsn}" }
-            end
-          end
-
-          it 'returns the default value' do
-            expect(klass.config.database.dsn).to eq('sqlite:memory')
-          end
-        end
-      end
-    end
-
-    describe 'configuration' do
-      context 'without nesting' do
-        context 'without processor' do
-          before do
-            klass.setting :dsn, 'sqlite:memory'
-          end
-
-          before do
-            klass.config.dsn = 'jdbc:sqlite:memory'
-          end
-
-          it 'updates the config value' do
-            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
-          end
-        end
-
-        context 'with processor' do
-          before do
-            klass.setting(:dsn, 'sqlite') { |dsn| "#{dsn}:memory" }
-          end
-
-          before do
-            klass.config.dsn = 'jdbc:sqlite'
-          end
-
-          it 'updates the config value' do
-            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
-          end
-        end
-      end
-
-      context 'with nesting' do
-        context 'without processor' do
-          before do
-            klass.setting :database do
-              setting :dsn, 'sqlite:memory'
-            end
-
-            klass.config.database.dsn = 'jdbc:sqlite:memory'
-          end
-
-          it 'updates the config value' do
-            expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
-          end
-        end
-
-        context 'with processor' do
-          before do
-            klass.setting :database do
-              setting(:dsn, 'sqlite') { |dsn| "#{dsn}:memory" }
-            end
-
-            klass.config.database.dsn = 'jdbc:sqlite'
-          end
-
-          it 'updates the config value' do
-            expect(klass.config.database.dsn).to eq('jdbc:sqlite:memory')
-          end
-        end
-      end
-
-      context 'when finalized' do
         before do
-          klass.setting :dsn
+          klass.setting(:dsn) { |dsn| "#{dsn}:memory" }
           klass.config.dsn = 'jdbc:sqlite'
-          klass.finalize!
         end
 
-        it 'disallows modification' do
-          expect do
-            klass.config.dsn = 'jdbc:sqlite'
-          end.to raise_error(Dry::Configurable::FrozenConfig, 'Cannot modify frozen config')
+        subject!(:subclass) { Class.new(klass) }
+
+        it 'retains its configuration' do
+          expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
         end
 
-        it 'disallows direct modification on config' do
-          expect do
-            klass.config.dsn = 'jdbc:sqlite:memory'
-          end.to raise_error(Dry::Configurable::FrozenConfig, 'Cannot modify frozen config')
-        end
-      end
-
-      context 'when inherited' do
-        context 'without processor' do
+        context 'when the inherited config is modified' do
           before do
-            klass.setting :dsn
-            klass.config.dsn = 'jdbc:sqlite:memory'
+            subclass.config.dsn = 'sqlite'
           end
-
-          subject!(:subclass) { Class.new(klass) }
-
-          it 'retains its configuration' do
-            expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
-          end
-
-          context 'when the inherited config is modified' do
-            before do
-              subclass.config.dsn = 'jdbc:sqlite:file'
-            end
-
-            it 'does not modify the original' do
-              expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
-              expect(subclass.config.dsn).to eq('jdbc:sqlite:file')
-            end
-          end
-        end
-
-        context 'with processor' do
-          before do
-            klass.setting(:dsn) { |dsn| "#{dsn}:memory" }
-            klass.config.dsn = 'jdbc:sqlite'
-          end
-
-          subject!(:subclass) { Class.new(klass) }
-
-          it 'retains its configuration' do
-            expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
-          end
-
-          context 'when the inherited config is modified' do
-            before do
-              subclass.config.dsn = 'sqlite'
-            end
-
-            it 'does not modify the original' do
-              expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
-              expect(subclass.config.dsn).to eq('sqlite:memory')
-            end
-          end
-        end
-
-        context 'when the inherited settings are modified' do
-          before do
-            klass.setting :dsn
-            subclass.setting :db
-            klass.config.dsn = 'jdbc:sqlite:memory'
-          end
-
-          subject!(:subclass) { Class.new(klass) }
 
           it 'does not modify the original' do
-            expect(klass.settings).to_not include(:db)
+            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+            expect(subclass.config.dsn).to eq('sqlite:memory')
           end
         end
       end
-    end
 
-    context 'Test Interface' do
-      before { klass.enable_test_interface }
-
-      describe 'reset_config' do
+      context 'when the inherited settings are modified' do
         before do
-          klass.setting :dsn, nil
-          klass.setting :pool do
-            setting :size, nil
-          end
-
-          klass.config.dsn = 'sqlite:memory'
-          klass.config.pool.size = 5
-
-          klass.reset_config
+          klass.setting :dsn
+          subclass.setting :db
+          klass.config.dsn = 'jdbc:sqlite:memory'
         end
 
-        it 'resets configuration to default values' do
-          expect(klass.config.dsn).to be_nil
-          expect(klass.config.pool.size).to be_nil
+        subject!(:subclass) { Class.new(klass) }
+
+        it 'does not modify the original' do
+          expect(klass.settings).to_not include(:db)
         end
       end
     end
+  end
 
-    context 'Try to set new value after config has been created' do
+  context 'Test Interface' do
+    before { klass.enable_test_interface }
+
+    describe 'reset_config' do
       before do
-        klass.setting :dsn, 'sqlite:memory'
-        klass.config
+        klass.setting :dsn, nil
+        klass.setting :pool do
+          setting :size, nil
+        end
+
+        klass.config.dsn = 'sqlite:memory'
+        klass.config.pool.size = 5
+
+        klass.reset_config
       end
 
-      it 'raise an exception' do
-        expect { klass.setting :pool, 5 }.to raise_error(
-          Dry::Configurable::AlreadyDefinedConfig
-        )
+      it 'resets configuration to default values' do
+        expect(klass.config.dsn).to be_nil
+        expect(klass.config.pool.size).to be_nil
       end
+    end
+  end
+
+  context 'Try to set new value after config has been created' do
+    before do
+      klass.setting :dsn, 'sqlite:memory'
+      klass.config
+    end
+
+    it 'raise an exception' do
+      expect { klass.setting :pool, 5 }.to raise_error(
+        Dry::Configurable::AlreadyDefinedConfig
+      )
     end
   end
 end

--- a/spec/unit/dry/configurable/argument_parser_spec.rb
+++ b/spec/unit/dry/configurable/argument_parser_spec.rb
@@ -1,39 +1,52 @@
 RSpec.describe Dry::Configurable::ArgumentParser do
-  let(:klass) { Dry::Configurable::ArgumentParser }
+  let(:undefined) { Dry::Configurable::Undefined }
+
+  let(:parser) { Dry::Configurable::ArgumentParser.new }
+
+  let(:value) { undefined }
+
+  let(:options) { undefined }
+
+  let(:block) { nil }
+
+  let(:output) { parser.(value, options, block) }
+
+  let(:parsed_value) { output[0] }
+
+  let(:parsed_options) { output[1] }
+
+  let(:parsed_processor) { output[2] }
 
   context 'with no args' do
-    let(:parsed) { klass.new([]) }
-
-    it 'return default values' do
-      expect(parsed.value).to eq nil
-      expect(parsed.options).to eq({})
+    it 'returns default values' do
+      expect(parsed_value).to eql(undefined)
+      expect(parsed_options).to eql(reader: false)
     end
   end
 
   context 'with value and options' do
-    let(:parsed) { klass.new([value, options]) }
-
     context 'valid options' do
       let(:value) { 'dry-rb' }
+
       let(:options) do
         { reader: true }
       end
 
       it 'returns correct value and options' do
-        expect(parsed.value).to eq 'dry-rb'
-        expect(parsed.options).to eq(reader: true)
+        expect(parsed_value).to eql('dry-rb')
+        expect(parsed_options).to eql(reader: true)
       end
     end
 
     context 'invalid options' do
       let(:value) { 'dry-rb' }
+
       let(:options) do
         { writer: true }
       end
 
-      it 'returns correct values and empty options' do
-        expect(parsed.value).to eq 'dry-rb'
-        expect(parsed.options).to eq({})
+      it 'rejects unknown options' do
+        expect { output }.to raise_error(ArgumentError)
       end
     end
 
@@ -41,37 +54,38 @@ RSpec.describe Dry::Configurable::ArgumentParser do
       let(:value) do
         { db: 'dry-rb' }
       end
+
       let(:options) do
         { reader: true }
       end
 
       it 'returns correct values and empty options' do
-        expect(parsed.value).to eq(db: 'dry-rb')
-        expect(parsed.options).to eq(reader: true)
+        expect(parsed_value).to eql(db: 'dry-rb')
+        expect(parsed_options).to eql(reader: true)
       end
     end
 
     context 'values as array' do
       let(:value) { [1, 2, 3] }
+
       let(:options) do
         { reader: true }
       end
 
       it 'returns correct values and empty options' do
-        expect(parsed.value).to eq([1, 2, 3])
-        expect(parsed.options).to eq(reader: true)
+        expect(parsed_value).to eql([1, 2, 3])
+        expect(parsed_options).to eql(reader: true)
       end
     end
   end
 
   context 'with value only' do
-    let(:parsed) { klass.new([value]) }
     context 'valid options' do
       let(:value) { 'dry-rb' }
 
       it 'returns correct value and options' do
-        expect(parsed.value).to eq 'dry-rb'
-        expect(parsed.options).to eq({})
+        expect(parsed_value).to eql('dry-rb')
+        expect(parsed_options).to eql(reader: false)
       end
     end
 
@@ -81,8 +95,8 @@ RSpec.describe Dry::Configurable::ArgumentParser do
       end
 
       it 'returns correct value and options' do
-        expect(parsed.value).to eq(writer: true)
-        expect(parsed.options).to eq({})
+        expect(parsed_value).to eql(writer: true)
+        expect(parsed_options).to eql(reader: false)
       end
     end
 
@@ -91,23 +105,21 @@ RSpec.describe Dry::Configurable::ArgumentParser do
         { reader: true, writer: true }
       end
 
-      it 'returns correct value and options' do
-        expect(parsed.value).to eq nil
-        expect(parsed.options).to eq(reader: true)
+      it 'rejects unknown options' do
+        expect { output }.to raise_error(ArgumentError)
       end
     end
   end
 
-  context 'with options only' do
-    let(:parsed) { klass.new([options]) }
+  context 'with valid options only' do
     context 'valid options' do
-      let(:options) do
+      let(:value) do
         { reader: true }
       end
 
       it 'returns correct value and options' do
-        expect(parsed.value).to eq nil
-        expect(parsed.options).to eq(reader: true)
+        expect(parsed_value).to be(undefined)
+        expect(parsed_options).to eql(reader: true)
       end
     end
   end

--- a/spec/unit/dry/configurable/config/value_spec.rb
+++ b/spec/unit/dry/configurable/config/value_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Dry::Configurable::Config::Value do
   describe '#value' do
     subject! { config.value }
 
-    context 'when value is not NONE' do
+    context 'when value is defined' do
       it { is_expected.to eq(value) }
     end
 
-    context 'when value is NONE' do
-      let(:value) { klass::NONE }
+    context 'when value is undefined' do
+      let(:value) { Dry::Configurable::Undefined }
 
       it { is_expected.to be(nil) }
     end
@@ -39,15 +39,15 @@ RSpec.describe Dry::Configurable::Config::Value do
     it { is_expected.to eq(processor) }
   end
 
-  describe '#none?' do
-    subject! { config.none? }
+  describe '#undefined?' do
+    subject! { config.undefined? }
 
-    context 'when value is not NONE' do
+    context 'when value is defined' do
       it { is_expected.to be(false) }
     end
 
-    context 'when value is NONE' do
-      let(:value) { klass::NONE }
+    context 'when value is undefined' do
+      let(:value) { Dry::Configurable::Undefined }
 
       it { is_expected.to be(true) }
     end

--- a/spec/unit/dry/configurable/config_spec.rb
+++ b/spec/unit/dry/configurable/config_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Dry::Configurable::Config do
     [
       value_class.new(:db, 'sqlite', ->(v) { "#{v}:memory" }),
       value_class.new(:user, 'root', ->(v) { v }),
-      value_class.new(:pass, none, ->(v) { v })
+      value_class.new(:pass, undefined, ->(v) { v })
     ]
   end
   let(:value_class) { Dry::Configurable::Config::Value }
-  let(:none) { value_class::NONE }
+  let(:undefined) { Dry::Configurable::Undefined }
 
   describe '.create' do
     it 'creates a config subclass from the given settings' do
@@ -85,7 +85,7 @@ RSpec.describe Dry::Configurable::Config do
         [
           value_class.new(:db, 'sqlite', ->(v) { "#{v}:memory" }),
           value_class.new(:user, 'root', ->(v) { v }),
-          value_class.new(:pass, none, ->(v) { v }),
+          value_class.new(:pass, undefined, ->(v) { v }),
           value_class.new(:foo, nested_setting, ->(v) { v })
         ]
       end
@@ -123,7 +123,7 @@ RSpec.describe Dry::Configurable::Config do
         [
           value_class.new(:db, 'sqlite', ->(v) { "#{v}:memory" }),
           value_class.new(:user, 'root', ->(v) { v }),
-          value_class.new(:pass, none, ->(v) { v }),
+          value_class.new(:pass, undefined, ->(v) { v }),
           value_class.new(:foo, nested_setting, ->(v) { v })
         ]
       end


### PR DESCRIPTION
* This adds support for instance-level configuring. For that, you use `include
Dry::Configurable` rather than `extend`.
* Internal NONE value was replaced with Undefined from dry-core (also dry-core is a dep
  now).
* ArgumentParser was reworked, it now handles processor, rejects unknown options
and always returns default options.