### PR TITLE
Travis: use 2.6.1; script directive is default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ dist: trusty
 sudo: required
 cache: bundler
 bundler_args: --without console
-script:
-  - bundle exec rake spec
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.0
+  - 2.6.1
   - jruby-9.2.5.0
 env:
   global:


### PR DESCRIPTION
This PR updates the CI matrix

 - use 2.6.1
  - the `script` directive was set to the same as the Travis default, so this PR removes that line