### PR TITLE
fix NoMethodError when reset module config

### DIFF
--- a/lib/dry/configurable/test_interface.rb
+++ b/lib/dry/configurable/test_interface.rb
@@ -8,7 +8,7 @@ module Dry
       #
       # @api public
       def reset_config
-        @config = if [Class, Module].include? self.class
+        @config = if self.is_a?(Module)
                     _settings.create_config
                   else
                     self.class._settings.create_config

--- a/lib/dry/configurable/test_interface.rb
+++ b/lib/dry/configurable/test_interface.rb
@@ -8,11 +8,11 @@ module Dry
       #
       # @api public
       def reset_config
-        if self.is_a?(Class)
-          @config = _settings.create_config
-        else
-          @config = self.class._settings.create_config
-        end
+        @config = if [Class, Module].include? self.class
+                    _settings.create_config
+                  else
+                    self.class._settings.create_config
+                  end
       end
     end
 

--- a/spec/integration/test_interface_spec.rb
+++ b/spec/integration/test_interface_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Dry::Configurable::TestInterface do
+  context "when configurable class" do
+    let(:klass) do
+      Class.new do
+        extend Dry::Configurable
+
+        setting :dsn
+      end
+    end
+
+    let(:object) { klass }
+
+    it_behaves_like 'valid test interface behavior'
+  end
+
+  context "when configurable module" do
+    let(:modulle) do
+      Module.new do
+        extend Dry::Configurable
+
+        setting :dsn
+      end
+    end
+
+    let(:object) { modulle }
+
+    it_behaves_like 'valid test interface behavior'
+  end
+
+  context "when configurable instance" do
+    let(:klass) do
+      Class.new do
+        include Dry::Configurable
+
+        setting :dsn
+      end
+    end
+
+    let(:object) { klass.new }
+
+    it_behaves_like 'valid test interface behavior'
+  end
+end

--- a/spec/support/shared_examples/test_interface.rb
+++ b/spec/support/shared_examples/test_interface.rb
@@ -1,0 +1,14 @@
+RSpec.shared_examples 'valid test interface behavior' do
+  before do
+    object.enable_test_interface
+    object.config.dsn = 'dsn_settings'
+  end
+
+  it 'drop settings to default' do
+    expect(object.config.dsn).to eq 'dsn_settings'
+
+    object.reset_config
+
+    expect(object.config.dsn).to be_nil
+  end
+end


### PR DESCRIPTION
Hello,
There is  ```NoMethodError: undefined method `_settings'``` when trying to perform ```reset_config``` method to module, extended by ```Dry::Configurable```.
Seems like it happens because of module doesn't pass check ```self.is_a?(Class)``` (because it is a ```Module``` class instead of ```Class``` class) and goes to ```else``` block, and ```_settings``` method applied to ruby ```Module``` class, which doesn't know about this method.
So, this PR fix this.