### PR TITLE
Support for reserved words in settings

### DIFF
--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -4,6 +4,8 @@ module Dry
     #
     # @private
     class Setting
+      VALID_NAME = /\A[a-z_]\w*\z/i
+
       attr_reader :name
 
       attr_reader :options
@@ -11,6 +13,9 @@ module Dry
       attr_reader :processor
 
       def initialize(name, value, processor, options = EMPTY_HASH)
+        unless VALID_NAME =~ name.to_s
+          raise ArgumentError, "+#{name}+ is not a valid setting name"
+        end
         @name = name.to_sym
         @value = value
         @processor = processor
@@ -31,6 +36,10 @@ module Dry
 
       def node?
         Settings === @value
+      end
+
+      def reserved?
+        options[:reserved]
       end
     end
   end


### PR DESCRIPTION
All ruby keywords are supported without restriction since they are valid method names. Some Kernel methods (class and public_send) as well as Config instance methods (such as to_h, dup, etc) don't have method accessor but they are accessible via `[]` and `[]=`.  Invalid ruby method names and methods with special symbols (including ! and ?) are rejected.