### PR TITLE
Redefine existing setting in a subclass without a warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 cache: bundler
 bundler_args: --without console
 after_success:
-  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
+  - "[ -d coverage ] && bundle exec codeclimate-test-reporter"
 rvm:
   - 2.4.6
   - 2.5.5
@@ -14,6 +14,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: truffleruby
+    - rvm: jruby-9.2.7.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
@@ -23,6 +24,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/19098b4253a72c9796db
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_success: change # options: [always|never|change] default: always
+    on_failure: always # options: [always|never|change] default: always
+    on_start: false # default: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ group :test do
     gem 'codeclimate-test-reporter', require: false
     gem 'simplecov', require: false
   end
+
+  gem 'warning'
 end
 
 group :tools do

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -65,13 +65,12 @@ module Dry
       #
       # @api public
       def setting(key, value = Undefined, options = Undefined, &block)
-        extended = singleton_class < Configurable
         raise_already_defined_config(key) if _settings.config_defined?
 
         setting = _settings.add(key, value, options, &block)
 
         if setting.reader?
-          readers = extended ? singleton_class : self
+          readers = singleton_class < Configurable ? singleton_class : self
           readers.send(:define_method, setting.name) { config[setting.name] }
         end
       end

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -57,6 +57,7 @@ module Dry
         *args, opts = Parser.(value, options, block)
 
         Setting.new(key, *args, { **opts, reserved: reserved?(key) }).tap do |s|
+          settings.delete_if { |e| e.name.eql?(s.name) }
           settings << s
           index[s.name] = s
           @names = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,10 @@ begin
 rescue LoadError
 end
 
+require 'warning'
+
+Warning.process { |w| raise RuntimeError, w }
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/shared_examples/class_level.rb
+++ b/spec/support/shared_examples/class_level.rb
@@ -93,6 +93,29 @@ RSpec.shared_examples 'a configurable class' do
           expect(klass.config.nested.thing).to eql('from base klass')
         end
       end
+
+      context 'redefining settings in subclasses' do
+        let(:klass) do
+          Class.new do
+            extend Dry::Configurable
+
+            setting :some, :parent
+          end
+        end
+
+        let(:subclass) do
+          Class.new(klass) do
+            setting :some, :child
+          end
+        end
+
+        before { subclass }
+
+        it 'is working w/o a warning' do
+          expect(klass.config.some).to be(:parent)
+          expect(subclass.config.some).to be(:child)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It used to issue a warning about redefined method.