### PR TITLE
Suppress keyword argument warnings in Ruby 2.7

### DIFF
--- a/lib/dry/configurable/settings/argument_parser.rb
+++ b/lib/dry/configurable/settings/argument_parser.rb
@@ -38,7 +38,7 @@ module Dry
             end
           end
 
-          [value, processor, options(Undefined.default(options, EMPTY_HASH))]
+          [value, processor, options(**Undefined.default(options, EMPTY_HASH))]
         end
 
         def options(reader: false)


### PR DESCRIPTION
This PR suppresses the following keyword argument warnings when using Ruby 2.7.

```console
/Users/koic/src/github.com/dry-rb/dry-configurable/lib/dry/configurable/settings/argument_parser.rb:41:
warning: The last argument is used as the keyword parameter
/Users/koic/src/github.com/dry-rb/dry-configurable/lib/dry/configurable/settings/argument_parser.rb:44:
warning: for `options' defined here
```

And this PR fixes the following and other testing errors occurred by warning gem.

```console
% ruby -v
ruby 2.7.0dev (2019-09-14T09:21:37Z master 39c37acf86) [x86_64-darwin17]
% bundle exec rake
(snip)

  143) Dry::Configurable when included with a constructor in the base
       class allows to configure class instances
     Failure/Error: Warning.process { |w| raise RuntimeError, w }

     RuntimeError:
       /Users/koic/src/github.com/dry-rb/dry-configurable/lib/dry/configurable/settings/argument_parser.rb:41:
warning: The last argument is used as the keyword parameter
     # ./spec/spec_helper.rb:21:in `block in <top (required)>'
     # ./lib/dry/configurable/settings/argument_parser.rb:41:in `call'
```

cf. https://bugs.ruby-lang.org/issues/14183