### PR TITLE
Fix inheritance when parent class already defined its config object

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -136,8 +136,9 @@ module Dry
     #
     # @api public
     def config
-      return @config if @config.defined?
+      return @config if defined?(@config) && @config.defined?
 
+      @config = _settings.create_config unless defined?(@config)
       @config.define!
     end
 

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -102,12 +102,14 @@ module Dry
       # @private
       def inherited(subclass)
         parent = self
+
         subclass.instance_exec do
           @settings = parent._settings.dup
         end
 
         if singleton_class < Configurable
           parent_config = @config
+
           subclass.instance_exec do
             @config = _settings.create_config
             @config.define!(parent_config.to_h) if parent_config.defined?

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -102,20 +102,9 @@ module Dry
       # @private
       def inherited(subclass)
         parent = self
-
         subclass.instance_exec do
           @settings = parent._settings.dup
         end
-
-        if singleton_class < Configurable
-          parent_config = @config
-
-          subclass.instance_exec do
-            @config = _settings.create_config
-            @config.define!(parent_config.to_h) if parent_config.defined?
-          end
-        end
-
         super
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,13 +15,6 @@ begin
 rescue LoadError
 end
 
-require 'warning'
-
-Warning.ignore(/rspec\/mocks/)
-Warning.ignore(/codacy/)
-
-Warning.process { |w| raise RuntimeError, w }
-
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/shared_examples/class_level.rb
+++ b/spec/support/shared_examples/class_level.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples 'a configurable class' do
         let(:subclass) { Class.new(klass) }
 
         it 'retains its configuration' do
-          expect(subclass.config.dsn).to eql('jdbc:sqlite:memory')
+          expect(object.config.dsn).to eql('jdbc:sqlite:memory')
         end
 
         context 'when the inherited config is modified' do
@@ -36,7 +36,7 @@ RSpec.shared_examples 'a configurable class' do
         subject!(:subclass) { Class.new(klass) }
 
         it 'retains its configuration' do
-          expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
+          expect(object.config.dsn).to eq('jdbc:sqlite:memory')
         end
 
         context 'when the inherited config is modified' do

--- a/spec/unit/dry/configurable/inherited_spec.rb
+++ b/spec/unit/dry/configurable/inherited_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Configurable, '.inherited' do
+  it 'copies the config' do
+    parent = Class.new do
+      extend Dry::Configurable
+
+      setting :foo, 'bar'
+    end
+
+    # it's important to trigger config here because it gets
+    # finalized, and we want to ensure that the child class
+    # can still expand its own config with new settings
+    expect(parent.config.foo).to eql('bar')
+
+    child = Class.new(parent) do
+      setting :custom, true
+    end
+
+    expect(child.config.foo).to eql('bar')
+    expect(child.config.custom).to be(true)
+  end
+end


### PR DESCRIPTION
Previously the inheritance hook would immediately set config on a child class which would later on prevent child class to define its own settings.