### PR TITLE
Store settings as symbol and fetch them from symbol or string

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -33,6 +33,7 @@ module Dry
       #
       # @return Config value
       def [](name)
+        name = name.to_sym
         raise ArgumentError, "+#{name}+ is not a setting name" unless _settings.key?(name)
 
         _settings[name].value

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -43,7 +43,7 @@ module Dry
 
         default, opts = args
 
-        node = [:setting, [name, default, opts == default ? EMPTY_HASH : opts]]
+        node = [:setting, [name.to_sym, default, opts == default ? EMPTY_HASH : opts]]
 
         if block
           if block.arity.zero?

--- a/spec/integration/dry/configurable/config_spec.rb
+++ b/spec/integration/dry/configurable/config_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe Dry::Configurable::Config do
   end
 
   describe '#[]' do
+    it 'coerces name from string' do
+      klass.setting :db, :sqlite
+
+      expect(klass.config['db']).to eql(:sqlite)
+    end
+
     it 'raises ArgumentError when name is not valid' do
       expect { klass.config[:hello] }.to raise_error(ArgumentError, /hello/)
     end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Dry::Configurable, '.setting' do
       )
     end
 
+    it 'stores setting name as symbol' do
+      klass.setting 'db', 'sqlite'
+
+      expect(object.config.values.keys).to include(:db)
+    end
+
     context 'with a default value' do
       context 'string' do
         before do


### PR DESCRIPTION
Closes #82

I also added the counter part: always coercing name to symbol when storing a setting. Otherwise fetching a string setting would fail if a symbol were provided.