### PR TITLE
WIP Forwarding setting with default value

### DIFF
--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.value).to eql('jdbc:sqlite')
   end
 
+  it 'compiles a setting with a constructor and no default value' do
+    setting = dsl.setting(:name) { |value| value.upcase }
+
+    expect(setting.name).to be(:name)
+    # What should we expect for setting.value?
+    expect(setting.value).to eql('jdbc:')
+  end
+
   it 'compiles a nested list of settings' do
     setting =
       dsl.setting(:db) do


### PR DESCRIPTION
In relation with a [topic discussed in the chat](https://dry-rb.zulipchat.com/#narrow/stream/191662-general/topic/dry-configurable/near/188869250). @solnic I think I've managed to isolate the main problem I'm having.

This WIP PR has a failing test which should be working before last major update. When the setting in `Glass` has no pre-processor then it works, but when it has one it seems it's not called when setting from `Klass`:

```
 1) Dry::Configurable::Config#forwarding can forward setting to another class
     Failure/Error: value.upcase
     
     NoMethodError:
       undefined method `upcase' for nil:NilClass
```

Any idea what it's going on?

Thanks