### PR TITLE
Don't generate Setting#inspect based on its equalizable attributes

### DIFF
--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -13,7 +13,7 @@ module Dry
     #
     # @api private
     class Setting
-      include Dry::Equalizer(:name, :value, :options)
+      include Dry::Equalizer(:name, :value, :options, inspect: false)
 
       OPTIONS = %i[input default reader constructor settings].freeze
 


### PR DESCRIPTION
This can cause crashes when inspecting settings that are yet to have a value applied (e.g. when they have a constructor that expects a value to be present)