### PR TITLE
Do not clone unevaluated values when copying Settings

### DIFF
--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -63,8 +63,18 @@ module Dry
       end
 
       # @api private
+      def input_defined?
+        !input.equal?(Undefined)
+      end
+
+      # @api private
       def value
         @value ||= evaluate
+      end
+
+      # @api private
+      def evaluated?
+        instance_variable_defined?(:@value)
       end
 
       # @api private
@@ -107,7 +117,7 @@ module Dry
       # @api private
       def initialize_copy(source)
         super
-        @value = source.value.dup if source.clonable_value?
+        @value = source.value.dup if source.input_defined? && source.clonable_value?
         @options = source.options.dup
       end
 


### PR DESCRIPTION
This is important for working with settings that have a constructor, but have not been provided an input yet.

This makes it possible to build settings with constructors expecting certain types of values, and then progressively apply those values across a range of settings on an object before finalizing it.