### PR TITLE
Avoid simple YARD warning

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -50,7 +50,7 @@ module Dry
 
       # Update config with new values
       #
-      # @param [Hash] A hash with new values
+      # @param values [Hash] A hash with new values
       #
       # @return [Config]
       #


### PR DESCRIPTION
This PR avoids this YARD warning:

> lib/dry/configurable/config.rb:53: [UnknownParam] @param tag has unknown parameter name: A