### PR TITLE
Raise meaningful exception upon double inclusion

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -7,6 +7,7 @@ require 'dry/configurable/class_methods'
 require 'dry/configurable/instance_methods'
 require 'dry/configurable/config'
 require 'dry/configurable/setting'
+require 'dry/configurable/errors'
 
 module Dry
   # A simple configuration mixin
@@ -51,6 +52,8 @@ module Dry
 
     # @api private
     def self.included(klass)
+      raise AlreadyIncluded if klass.include?(InstanceMethods)
+
       super
       klass.class_eval do
         extend(ClassMethods)

--- a/lib/dry/configurable/errors.rb
+++ b/lib/dry/configurable/errors.rb
@@ -6,6 +6,7 @@ module Dry
   # @api public
   module Configurable
     Error = Class.new(::StandardError)
+    AlreadyIncluded = ::Class.new(Error)
     FrozenConfig = ::Class.new(Error)
   end
 end

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Configurable, '.included' do
+  let(:configurable_klass) { Class.new.include(Dry::Configurable) }
+
+  it 'extends ClassMethods' do
+    expect(configurable_klass.singleton_class.included_modules)
+      .to include(Dry::Configurable::ClassMethods)
+  end
+
+  it 'includes InstanceMethods' do
+    expect(configurable_klass.included_modules)
+      .to include(Dry::Configurable::InstanceMethods)
+  end
+
+  it 'raises when Dry::Configurable has already been included' do
+    expect {
+      configurable_klass.include(Dry::Configurable)
+    }.to raise_error(Dry::Configurable::AlreadyIncluded)
+  end
+
+  it 'ensures `.config` is not defined' do
+    expect(configurable_klass).not_to respond_to(:config)
+  end
+
+  it 'ensures `.configure` is not defined' do
+    expect(configurable_klass).not_to respond_to(:configure)
+  end
+end


### PR DESCRIPTION
Currently, when an object mixes in Dry::Configurable more than once a `NameError` exception is incidentally raised. This is due to `.config` and `.configure` being already undefined.

This change introduces `AlreadyIncluded`, which is meant to be a more understandable signal that `include` has been called twice. It's raised if `InstanceMethods` has been previously mixed in. While it would be ideal to raise if `Dry::Configurable` itself had been mixed in, Ruby's `included` hook is not triggered until _after_ the [module has been included](https://ruby-doc.org/core-2.7.0/Module.html#method-i-include).

Closes #89 