### PR TITLE
Evaluate setting immediately if input defined

### DIFF
--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -60,6 +60,8 @@ module Dry
         @input = input.equal?(Undefined) ? default : input
         @default = default
         @options = options
+
+        evaluate if input_defined?
       end
 
       # @api private


### PR DESCRIPTION
This makes it possible for immediate feedback to be provided to users if an input is provided for a setting that has a constructor designed to raise errors when invalid input is provided.

I've checked this change against dry-{schema,validation,system} and they're all still green.