### PR TITLE
Do not memoize config when using pre-process values

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -108,7 +108,9 @@ module Dry
         if setting.writer?(meth)
           raise FrozenConfig, 'Cannot modify frozen config' if frozen?
 
-          _settings << setting.with(input: args[0])
+          new_setting = setting.with(input: args[0])
+          new_setting.evaluate
+          _settings << new_setting
         else
           setting.value
         end

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -61,7 +61,7 @@ module Dry
         @default = default
         @options = options
 
-        evaluate if input_defined?
+        evaluate if input_defined? && !options[:constructor].is_a?(Proc)
       end
 
       # @api private

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -60,8 +60,6 @@ module Dry
         @input = input.equal?(Undefined) ? default : input
         @default = default
         @options = options
-
-        evaluate if input_defined? && !options[:constructor].is_a?(Proc)
       end
 
       # @api private
@@ -114,6 +112,11 @@ module Dry
         CLONABLE_VALUE_TYPES.any? { |type| value.is_a?(type) }
       end
 
+      # @api private
+      def evaluate
+        @value = constructor[input.equal?(Undefined) ? nil : input]
+      end
+
       private
 
       # @api private
@@ -121,11 +124,6 @@ module Dry
         super
         @value = source.value.dup if source.input_defined? && source.clonable_value?
         @options = source.options.dup
-      end
-
-      # @api private
-      def evaluate
-        @value = constructor[input.equal?(Undefined) ? nil : input]
       end
     end
   end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -162,6 +162,27 @@ RSpec.describe Dry::Configurable, '.setting' do
         expect { klass.setting name }.to raise_error(ArgumentError, /not a valid/)
       end
     end
+
+    context 'allow immediate feedback on failable settings' do
+      before do
+        klass.setting :failable do |value|
+          value.to_sym unless value.nil?
+        end
+      end
+
+      it 'fail if using bad input with .config.setting=' do
+        expect do
+          object.config.failable = 12
+        end.to raise_error(NoMethodError, /undefined method `to_sym'/)
+      end
+      it 'assign input with .configure DSL' do
+        expect do
+          object.configure do |config|
+            config.failable = 12
+          end
+        end.to raise_error(NoMethodError, /undefined method `to_sym'/)
+      end
+    end
   end
 
   context 'when extended' do

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -305,6 +305,12 @@ RSpec.describe Dry::Configurable, '.setting' do
       expect(object.config.db).to eql('sqlite')
     end
 
+    it 'the config should not be memoized when used a constructor' do
+      klass.setting(:path, 'test') { |m| Pathname(m) }
+      new_object = klass.new
+      expect(object.config.path.object_id).not_to eql(new_object.config.path.object_id)
+    end
+
     shared_examples 'copying' do
       before do
         klass.setting :env

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -10,45 +10,31 @@ RSpec.describe Dry::Configurable::Setting do
 
   describe '#initialize' do
     describe 'input evaluation' do
-      let(:constructor) do
-        # Allow constructor calls to be observed
-        ctx = self
-        -> val {
-          ctx.instance_variable_set :@constructor_called, true
-          val
-        }
-      end
-
-      before do
-        @constructor_called = false
-      end
-
       context 'input defined' do
         let(:options) do
-          {input: 1, constructor: constructor}
+          { input: 1 }
         end
 
         it 'evaluates the input' do
           expect(setting).to be_evaluated
         end
 
-        it 'evaluates the input through the constructor' do
-          expect { setting }.to change { @constructor_called }.from(false).to true
+        context 'with constructor' do
+          let(:options) do
+            { input: 1, constructor: described_class::DEFAULT_CONSTRUCTOR }
+          end
+          it 'does not evaluates the input' do
+            expect(setting).not_to be_evaluated
+          end
         end
       end
 
       context 'input not defined' do
         let(:options) do
-          {constructor: constructor}
+          {}
         end
-
         it 'does not evaluates the input' do
           expect(setting).not_to be_evaluated
-        end
-
-        it 'does not call the constructor' do
-          expect { setting }.not_to change { @constructor_called }
-          expect(@constructor_called).to be false
         end
       end
     end

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Dry::Configurable::Setting do
           { input: 1 }
         end
 
-        it 'evaluates the input' do
-          expect(setting).to be_evaluated
+        it 'does not evaluates the input' do
+          expect(setting).not_to be_evaluated
         end
 
         context 'with constructor' do
@@ -110,8 +110,8 @@ RSpec.describe Dry::Configurable::Setting do
         {input: 2}
       end
 
-      it 'is true' do
-        expect(setting).to be_evaluated
+      it 'is false for a newly created setting' do
+        expect(setting).not_to be_evaluated
       end
     end
 


### PR DESCRIPTION
There's an corner case when a configuration should not be memoized
when using pre-processor values:

```ruby
MyMonitor = Class.new

class Producer
  include Dry::Configurable
  setting(:monitor, false) { |monitor| monitor || MyMonitor.new }
end

p01 = Producer.new
p02 = Producer.new

raise 'Not memoized allowed' \
    if p01.config.monitor.object_id == p01.config.monitor.object_id
```

This behavior was introduced on Dry::Config 0.11.6, on PR #95

Fixed #96

Notes: I'm modifying the tests for `Dry::Config::Setting` because the test
was interfeiring with the behavior when introduce a constructor which
happend to be exactly the issue when using the setting method.