### PR TITLE
Fix: InstanceMethods#initialize was not invoked

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -57,7 +57,7 @@ module Dry
       super
       klass.class_eval do
         extend(ClassMethods)
-        include(InstanceMethods)
+        prepend(InstanceMethods)
 
         class << self
           undef :config

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -1,29 +1,48 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Configurable, '.included' do
+  shared_examples 'configure' do
+    it 'extends ClassMethods' do
+      expect(configurable_klass.singleton_class.included_modules)
+        .to include(Dry::Configurable::ClassMethods)
+    end
+
+    it 'includes InstanceMethods' do
+      expect(configurable_klass.included_modules)
+        .to include(Dry::Configurable::InstanceMethods)
+    end
+
+    it 'raises when Dry::Configurable has already been included' do
+      expect {
+        configurable_klass.include(Dry::Configurable)
+      }.to raise_error(Dry::Configurable::AlreadyIncluded)
+    end
+
+    it 'ensures `.config` is not defined' do
+      expect(configurable_klass).not_to respond_to(:config)
+    end
+
+    it 'ensures `.configure` is not defined' do
+      expect(configurable_klass).not_to respond_to(:configure)
+    end
+
+    it 'ensures `#config` returns instance of Dry::Configurable::Config' do
+      expect(configurable_klass.new.config).to be_a(Dry::Configurable::Config)
+    end
+  end
+
   let(:configurable_klass) { Class.new.include(Dry::Configurable) }
 
-  it 'extends ClassMethods' do
-    expect(configurable_klass.singleton_class.included_modules)
-      .to include(Dry::Configurable::ClassMethods)
-  end
+  it_behaves_like 'configure'
 
-  it 'includes InstanceMethods' do
-    expect(configurable_klass.included_modules)
-      .to include(Dry::Configurable::InstanceMethods)
-  end
+  context 'when #initialize is defined in configurable class' do
+    let(:configurable_klass) do
+      Class.new do
+        include Dry::Configurable
+        def initialize; end
+      end
+    end
 
-  it 'raises when Dry::Configurable has already been included' do
-    expect {
-      configurable_klass.include(Dry::Configurable)
-    }.to raise_error(Dry::Configurable::AlreadyIncluded)
-  end
-
-  it 'ensures `.config` is not defined' do
-    expect(configurable_klass).not_to respond_to(:config)
-  end
-
-  it 'ensures `.configure` is not defined' do
-    expect(configurable_klass).not_to respond_to(:configure)
+    it_behaves_like 'configure'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'support/coverage'
+require 'pathname'
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 
@@ -8,8 +9,6 @@ begin
   require 'pry-byebug'
 rescue LoadError
 end
-
-require 'pathname'
 
 Dir[Pathname(__FILE__).dirname.join('support/**/*.rb').to_s].each do |file|
   require file


### PR DESCRIPTION
Hi!

When `#initialize` is defined in configurable class, `InstanceMethods#initialize`  was not invoked:

```ruby
class A
  include Dry::Configurable

  setting foo: 'bar'

  def initialize
  end
end

A.new.config #=> nil
```

Here's fix.