### PR TITLE
Prevent accidental memoization of values across setting instances

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,9 +1,12 @@
 ---
 - version: unreleased
-  summary: 
-  date: 
-  fixed: 
-  added: 
+  summary:
+  date:
+  fixed:
+  - 'Setting values provided by defaults and/or pre-processor blocks are
+    no longer accidentally memoized across instances of classes including
+    Dry::Configurable (#99) (@timriley & @esparta)'
+  added:
   changed:
   - 'Instance behavior is now prepended, so that if you have your own `initialize`,
     calling `super` is no longer required (see #98 for more details) (@zabolotnov87)'

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -121,6 +121,16 @@ RSpec.describe Dry::Configurable, '.setting' do
 
         expect(object.config.path).to eql(Pathname('test'))
       end
+
+      it 'raises pre-processor errors immediately' do
+        klass.setting :failable do |value|
+          value.to_sym unless value.nil?
+        end
+
+        expect {
+          object.config.failable = 12
+        }.to raise_error(NoMethodError, /undefined method `to_sym'/)
+      end
     end
 
     context 'with reader: true' do
@@ -303,6 +313,16 @@ RSpec.describe Dry::Configurable, '.setting' do
       klass.setting :db, 'sqlite'
 
       expect(object.config.db).to eql('sqlite')
+    end
+
+    it 'creates distinct setting values across instances' do
+      klass.setting(:path, 'test') { |m| Pathname(m) }
+
+      new_object = klass.new
+
+      expect(object.config.path).to eq Pathname('test')
+      expect(new_object.config.path).to eq Pathname('test')
+      expect(object.config.path).not_to be(new_object.config.path)
     end
 
     shared_examples 'copying' do

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Dry::Configurable::Setting do
         {default: 1}
       end
 
-      it 'is true' do
-        expect(setting.input_defined?).to be true
+      it 'is false' do
+        expect(setting.input_defined?).to be false
       end
     end
   end


### PR DESCRIPTION
We achieve this by:

1. Keeping the input and default separate when initialising a setting (instead of assigning the default to the input in the case of an undefined input)
2. Then moving the handling of the default into `#evaluate`, which provides the same outcome (the default will be used if the input is undefined), but makes it lazy, allowing the default to remain separated from the value as setting instances are cloned
3. When setting cloning happens, copy over all three of the input/default/value, which allows not-yet-evaluated Settings still to be cloned properly

Together, this allows for settings to raise errors immediately if assigned an input that does not meet the expectations of the pre-processor block, while also ensuring that in the case of a setting with a default but no input, that there is no accidental memoization of values across multiple instances (i.e. it makes _both_ the new test cases in this PR pass without compromising on the integrity of the `Setting` class)

Resolves #96, #97