### PR TITLE
Support custom cloneable values

### DIFF
--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -19,7 +19,7 @@ module Dry
 
       DEFAULT_CONSTRUCTOR = -> v { v }.freeze
 
-      CLONABLE_VALUE_TYPES = [Array, Hash, Set, Config].freeze
+      CLONEABLE_VALUE_TYPES = [Array, Hash, Set, Config].freeze
 
       # @api private
       attr_reader :name
@@ -54,8 +54,8 @@ module Dry
       end
 
       # @api private
-      def self.clonable_value?(value)
-        CLONABLE_VALUE_TYPES.any? { |type| value.is_a?(type) }
+      def self.cloneable_value?(value)
+        CLONEABLE_VALUE_TYPES.any? { |type| value.is_a?(type) }
       end
 
       # @api private
@@ -119,9 +119,9 @@ module Dry
       # @api private
       def initialize_copy(source)
         super
-        @input = source.input.dup if Setting.clonable_value?(source.input)
-        @default = source.default.dup if Setting.clonable_value?(source.default)
-        @value = source.value.dup if source.evaluated? && Setting.clonable_value?(source.value)
+        @input = source.input.dup if Setting.cloneable_value?(source.input)
+        @default = source.default.dup if Setting.cloneable_value?(source.default)
+        @value = source.value.dup if source.evaluated? && Setting.cloneable_value?(source.value)
         @options = source.options.dup
       end
 

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -55,7 +55,8 @@ module Dry
 
       # @api private
       def self.cloneable_value?(value)
-        CLONEABLE_VALUE_TYPES.any? { |type| value.is_a?(type) }
+        CLONEABLE_VALUE_TYPES.any? { |type| value.is_a?(type) } ||
+          (value.respond_to?(:cloneable_value?) && value.cloneable_value?)
       end
 
       # @api private

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Dry::Configurable::Setting do
         expect(copy.options).to_not be(setting.options)
       end
 
-      context 'with a clonable value' do
+      context 'with a cloneable value' do
         let(:options) do
           { input: [1, 2, 3] }
         end
@@ -199,7 +199,7 @@ RSpec.describe Dry::Configurable::Setting do
         end
       end
 
-      context 'with a non-clonable value' do
+      context 'with a non-cloneable value' do
         let(:options) do
           { input: :hello }
         end

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -199,6 +199,36 @@ RSpec.describe Dry::Configurable::Setting do
         end
       end
 
+      context 'with a custom object reporting as a cloneable value' do
+        let(:options) do
+          { input: custom_cloneable_class.new([1,2,3]) }
+        end
+
+        let(:custom_cloneable_class) do
+          Class.new {
+            attr_reader :value
+
+            def initialize(value)
+              @value = value
+            end
+
+            def initialize_copy(source)
+              super
+              @value = source.value.dup
+            end
+
+            def cloneable_value?
+              true
+            end
+          }
+        end
+
+        it 'maintains a copy of the value' do
+          expect(copy.value.value).to eql(setting.value.value)
+          expect(copy.value.value).to_not be(setting.value.value)
+        end
+      end
+
       context 'with a non-cloneable value' do
         let(:options) do
           { input: :hello }


### PR DESCRIPTION
With this change, setting value objects responding to `#cloneable_value?` and returning true will be cloned when settings are cloned or dup’ed, in addition to the existing fixed set of classes (Array, Hash, Set, Config).

This makes it possible to provide “rich” config values that carry their own configuration interface, e.g.

```ruby
setting :component_dirs, Configuration::ComponentDirs.new
```

In this case, `ComponentDirs` could provide its own API for adding component dirs and configuring aspects of their behavior at the same time. Provided it implements its own appropriate `#initialize_copy` and then returns true to `#cloneable_value?`, dry-configurable will ensure that this value is cloned along its setting at the appropriate times.

As the example above indicates, this change is in service of dry-system providing a new ”rich” `component_dirs` setting, providing an API like this:

```ruby
# Inside a Dry::System::Container subclass
configure do |config|
  config.component_dirs.add("path/to/dir") do |dir|
    dir.auto_register = true
    dir.add_to_load_path = true
    # etc.
  end
end
```