### PR TITLE
Attempt to call super in finalize! method

### DIFF
--- a/lib/dry/configurable/methods.rb
+++ b/lib/dry/configurable/methods.rb
@@ -25,6 +25,9 @@ module Dry
         return self if config.frozen?
 
         config.finalize!
+
+        super if defined?(super)
+
         self
       end
     end

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe Dry::Configurable, '.included' do
 
     it_behaves_like 'configure'
   end
+
+  context 'when #finalize! is defined in configurable class' do
+    let(:instance) do
+      Class.new do
+        include Dry::Configurable
+
+        attr_accessor :finalized
+
+        def finalize!
+          @finalized = true
+        end
+      end.new
+    end
+
+    it 'calls finalize! in configurable class' do
+      instance.finalize!
+      expect(instance.finalized).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
The `Dry::Configurable::Methods` module ends up in the ancestory
tree, but fails to call `super`.

This breaks scenarios where `finalize!` has been defined in a
configurable class, since the `finalize!` method in that class is the
third in the tree and is never reached.

Fixes https://github.com/hanami/view/issues/184