### PR TITLE
Add `cloneable` setting option

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,4 +1,25 @@
 ---
+- version: Unreleased
+  summary:
+  date:
+  added:
+  - |-
+    Settings may be specified with a `cloneable` option, e.g.
+
+    ```ruby
+    setting :component_dirs, Configuration::ComponentDirs.new, cloneable: true
+    ```
+
+    This change makes it possible to provide “rich” config values that carry their own
+    configuration interface.
+
+    In the above example, `ComponentDirs` could provide its own API for adding component
+    dirs and configuring aspects of their behavior at the same time. By being passed to
+    the setting along with `cloneable: true`, dry-configurable will ensure the setting's
+    values are cloned along with the setting at all the appropriate times.
+
+    A custom cloneable setting value should provide its own `#initialize_copy` (used by
+    `Object#dup`) with the appropriate logic. (@timriley in #102)
 - version: 0.12.0
   summary:
   date: '2020-12-26'

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -19,7 +19,7 @@ module Dry
 
       DEFAULT_CONSTRUCTOR = -> v { v }.freeze
 
-      CLONABLE_VALUE_TYPES = [Array, Hash, Set, Config].freeze
+      CLONEABLE_VALUE_TYPES = [Array, Hash, Set, Config].freeze
 
       # @api private
       attr_reader :name
@@ -54,8 +54,8 @@ module Dry
       end
 
       # @api private
-      def self.clonable_value?(value)
-        CLONABLE_VALUE_TYPES.any? { |type| value.is_a?(type) }
+      def self.cloneable_value?(value)
+        CLONEABLE_VALUE_TYPES.any? { |type| value.is_a?(type) }
       end
 
       # @api private
@@ -119,9 +119,9 @@ module Dry
       # @api private
       def initialize_copy(source)
         super
-        @input = source.input.dup if Setting.clonable_value?(source.input)
-        @default = source.default.dup if Setting.clonable_value?(source.default)
-        @value = source.value.dup if source.evaluated? && Setting.clonable_value?(source.value)
+        @input = source.input.dup if Setting.cloneable_value?(source.input)
+        @default = source.default.dup if Setting.cloneable_value?(source.default)
+        @value = source.value.dup if source.evaluated? && Setting.cloneable_value?(source.value)
         @options = source.options.dup
       end
 

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -15,7 +15,7 @@ module Dry
     class Setting
       include Dry::Equalizer(:name, :value, :options, inspect: false)
 
-      OPTIONS = %i[input default reader constructor settings].freeze
+      OPTIONS = %i[input default reader constructor cloneable settings].freeze
 
       DEFAULT_CONSTRUCTOR = -> v { v }.freeze
 
@@ -114,15 +114,32 @@ module Dry
         writer_name.equal?(meth)
       end
 
+      # @api private
+      def cloneable?
+        if options.key?(:cloneable)
+          # Return cloneable option if explicitly set
+          options[:cloneable]
+        else
+          # Otherwise, infer cloneable from any of the input, default, or value
+          Setting.cloneable_value?(input) || Setting.cloneable_value?(default) || (
+            evaluated? && Setting.cloneable_value?(value)
+          )
+        end
+      end
+
       private
 
       # @api private
       def initialize_copy(source)
         super
-        @input = source.input.dup if Setting.cloneable_value?(source.input)
-        @default = source.default.dup if Setting.cloneable_value?(source.default)
-        @value = source.value.dup if source.evaluated? && Setting.cloneable_value?(source.value)
+
         @options = source.options.dup
+
+        if source.cloneable?
+          @input = source.input.dup
+          @default = source.default.dup
+          @value = source.value.dup if source.evaluated?
+        end
       end
 
       # @api private

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Dry::Configurable::Setting do
         expect(copy.options).to_not be(setting.options)
       end
 
-      context 'with a clonable value' do
+      context 'with a cloneable value' do
         let(:options) do
           { input: [1, 2, 3] }
         end
@@ -199,7 +199,7 @@ RSpec.describe Dry::Configurable::Setting do
         end
       end
 
-      context 'with a non-clonable value' do
+      context 'with a non-cloneable value' do
         let(:options) do
           { input: :hello }
         end

--- a/spec/unit/dry/configurable/setting_spec.rb
+++ b/spec/unit/dry/configurable/setting_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Dry::Configurable::Setting do
         expect(copy.options).to_not be(setting.options)
       end
 
-      context 'with a cloneable value' do
+      context 'with a naturally cloneable value' do
         let(:options) do
           { input: [1, 2, 3] }
         end
@@ -199,7 +199,28 @@ RSpec.describe Dry::Configurable::Setting do
         end
       end
 
-      context 'with a non-cloneable value' do
+      context 'with cloneable option as true' do
+        let(:options) do
+          { input: "hello", cloneable: true }
+        end
+
+        it 'maintains a copy of the value' do
+          expect(copy.value).to eql(setting.value)
+          expect(copy.value).to_not be(setting.value)
+        end
+      end
+
+      context 'with cloneable option as false' do
+        let(:options) do
+          { input: [1, 2, 3], cloneable: false }
+        end
+
+        it 'maintains the original value' do
+          expect(copy.value).to be(setting.value)
+        end
+      end
+
+      context 'with a naturally non-cloneable value' do
         let(:options) do
           { input: :hello }
         end


### PR DESCRIPTION
This is an evolution from the approach in #100. With this change, settings may be specified with a `cloneable` option, e.g.

```ruby
setting :component_dirs, Configuration::ComponentDirs.new, cloneable: true
```

This makes it possible to provide “rich” config values that carry their own configuration interface.

In the example above, `ComponentDirs` could provide its own API for adding component dirs and configuring aspects of their behavior at the same time. By being passed to the setting along with `cloneable: true`, dry-configurable will ensure the setting's values are cloned along with the setting at all the appropriate times (see `Setting#initialize_copy`).

As the example here suggests, this change is in service of dry-system providing a new ”rich” `component_dirs` setting, providing an API like this:

```ruby
# Inside a Dry::System::Container subclass
configure do |config|
  config.component_dirs.add("path/to/dir") do |dir|
    dir.auto_register = true
    dir.add_to_load_path = true
    # etc.
  end
end
```