### PR TITLE
Prepend initialize method only

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -57,7 +57,8 @@ module Dry
       super
       klass.class_eval do
         extend(ClassMethods)
-        prepend(InstanceMethods)
+        include(InstanceMethods)
+        prepend(Initializer)
 
         class << self
           undef :config

--- a/lib/dry/configurable/instance_methods.rb
+++ b/lib/dry/configurable/instance_methods.rb
@@ -5,6 +5,18 @@ require 'dry/configurable/methods'
 
 module Dry
   module Configurable
+    # Initializer method which is prepended when `Dry::Configurable`
+    # is included in a class
+    #
+    # @api private
+    module Initializer
+      # @api private
+      def initialize(*)
+        @config = Config.new(self.class._settings.dup)
+        super
+      end
+    end
+
     # Instance-level API when `Dry::Configurable` is included in a class
     #
     # @api public
@@ -17,12 +29,6 @@ module Dry
       #
       # @api public
       attr_reader :config
-
-      # @api private
-      def initialize(*)
-        @config = Config.new(self.class._settings.dup)
-        super
-      end
 
       # Finalize the config and freeze the object
       #

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe Dry::Configurable, '.included' do
 
     it_behaves_like 'configure'
   end
+
+  context 'when #finalize! is defined in configurable class' do
+    let(:instance) do
+      Class.new do
+        include Dry::Configurable
+
+        attr_accessor :finalized
+
+        def finalize!
+          @finalized = true
+        end
+      end.new
+    end
+
+    it 'calls finalize! in configurable class' do
+      instance.finalize!
+      expect(instance.finalized).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Move initialize method to it's own module and prepend
it inside the `include` hook.

Revert the prepending of `InstanceMethods` module in
favour of using `include`.

Fixes instances where `finalize!` methods in classes that
include `Dry::Configurable` are never called due to the
ancestor chain.

Fixes hanami/view#184