### PR TITLE
Deprecate constructor as a block

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -28,7 +28,7 @@ class App
   end
   # Defaults to nil if no default value is given
   setting :adapter
-  # Pre-process values
+  # Construct values
   setting(:path, 'test') { |value| Pathname(value) }
   # Passing the reader option as true will create attr_reader method for the class
   setting :pool, 5, reader: true

--- a/lib/dry/configurable/compiler.rb
+++ b/lib/dry/configurable/compiler.rb
@@ -24,12 +24,6 @@ module Dry
       end
 
       # @api private
-      def visit_constructor(node)
-        setting, constructor = node
-        visit(setting).with(constructor: constructor)
-      end
-
-      # @api private
       def visit_setting(node)
         name, default, opts = node
         Setting.new(name, **opts, default: default)

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -5,6 +5,7 @@ require 'dry/configurable/setting'
 require 'dry/configurable/settings'
 require 'dry/configurable/compiler'
 require 'dry/configurable/dsl/args'
+require 'dry/core/deprecations'
 
 module Dry
   module Configurable
@@ -49,6 +50,11 @@ module Dry
           if block.arity.zero?
             ast << [:nested, [node, DSL.new(&block).ast]]
           else
+            Dry::Core::Deprecations.announce(
+              'passing a constructor as a block',
+              'Provide a `constructor:` keyword argument instead',
+              tag: 'dry-configurable'
+            )
             ast << [:constructor, [node, block]]
           end
         else

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -44,19 +44,20 @@ module Dry
 
         default, opts = args
 
+        if block && !block.arity.zero?
+          Dry::Core::Deprecations.announce(
+            'passing a constructor as a block',
+            'Provide a `constructor:` keyword argument instead',
+            tag: 'dry-configurable'
+          )
+          opts = opts.merge(constructor: block)
+          block = nil
+        end
+
         node = [:setting, [name.to_sym, default, opts == default ? EMPTY_HASH : opts]]
 
         if block
-          if block.arity.zero?
-            ast << [:nested, [node, DSL.new(&block).ast]]
-          else
-            Dry::Core::Deprecations.announce(
-              'passing a constructor as a block',
-              'Provide a `constructor:` keyword argument instead',
-              tag: 'dry-configurable'
-            )
-            ast << [:constructor, [node, block]]
-          end
+          ast << [:nested, [node, DSL.new(&block).ast]]
         else
           ast << node
         end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe Dry::Configurable, '.setting' do
       end
     end
 
-    context 'with a value pre-processor' do
-      it 'pre-processes the value with nil default' do
-        klass.setting(:path, nil) { |value| "test:#{value || "fallback"}" }
+    context 'with a value constructor' do
+      it 'constructs the value with nil default' do
+        klass.setting(:path, nil, constructor: ->(value) { "test:#{value || "fallback"}" })
 
         expect(object.config.path).to eql("test:fallback")
 
@@ -110,22 +110,20 @@ RSpec.describe Dry::Configurable, '.setting' do
         expect(object.config.path).to eql('test:foo')
       end
 
-      it 'pre-processes the value with undefined default' do
-        klass.setting(:path) { |value| "test:#{value || "fallback"}" }
+      it 'constructs the value with undefined default' do
+        klass.setting(:path, constructor: ->(value) { "test:#{value || "fallback"}" })
 
         expect(object.config.path).to eql('test:fallback')
       end
 
-      it 'pre-processes the value with non-nil default' do
-        klass.setting(:path, 'test') { |value| Pathname(value) }
+      it 'constructs the value with non-nil default' do
+        klass.setting(:path, 'test', constructor: ->(value) { Pathname(value) })
 
         expect(object.config.path).to eql(Pathname('test'))
       end
 
-      it 'raises pre-processor errors immediately' do
-        klass.setting :failable do |value|
-          value.to_sym unless value.nil?
-        end
+      it 'raises constructor errors immediately' do
+        klass.setting(:failable, constructor: ->(value) { value.to_sym unless value.nil? })
 
         expect {
           object.config.failable = 12
@@ -316,7 +314,7 @@ RSpec.describe Dry::Configurable, '.setting' do
     end
 
     it 'creates distinct setting values across instances' do
-      klass.setting(:path, 'test') { |m| Pathname(m) }
+      klass.setting(:path, 'test', constructor: ->(m) { Pathname(m) })
 
       new_object = klass.new
 

--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -50,12 +50,14 @@ RSpec.describe Dry::Configurable::DSL do
   end
 
   it 'supports but deprecates giving a constructor as a block' do
-    expect(Dry::Core::Deprecations).to receive(:announce)
+    logger = StringIO.new
+    Dry::Core::Deprecations.logger(logger)
 
     setting = dsl.setting(:dsn, 'sqlite') { |value| "jdbc:#{value}" }
 
     expect(setting.name).to be(:dsn)
     expect(setting.value).to eql('jdbc:sqlite')
+    expect(logger.string).to include('constructor as a block is deprecated')
   end
 
   it 'compiles a nested list of settings' do

--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe Dry::Configurable::DSL do
   end
 
   it 'compiles a setting with a constructor' do
+    setting = dsl.setting(:dsn, 'sqlite', constructor: ->(value) { "jdbc:#{value}" })
+
+    expect(setting.name).to be(:dsn)
+    expect(setting.value).to eql('jdbc:sqlite')
+  end
+
+  it 'supports but deprecates giving a constructor as a block' do
+    expect(Dry::Core::Deprecations).to receive(:announce)
+
     setting = dsl.setting(:dsn, 'sqlite') { |value| "jdbc:#{value}" }
 
     expect(setting.name).to be(:dsn)


### PR DESCRIPTION
So far, we have been accepting both a block and the `constructor:`
keyword argument for providing a constructor. The former will not be
available in 1.0, so we're deprecating it now.

We also prepare the test suite for the change and make naming consistent
using "constructor" where we were using "pre-processor."