### PR TITLE
Forward keyword args to initialize

### DIFF
--- a/lib/dry/configurable/instance_methods.rb
+++ b/lib/dry/configurable/instance_methods.rb
@@ -11,9 +11,16 @@ module Dry
     # @api private
     module Initializer
       # @api private
-      def initialize(*)
-        @config = Config.new(self.class._settings.dup)
-        super
+      if RUBY_VERSION >= "2.7"
+        def initialize(*, **)
+          @config = Config.new(self.class._settings.dup)
+          super
+        end
+      else
+        def initialize(*)
+          @config = Config.new(self.class._settings.dup)
+          super
+        end
       end
     end
 

--- a/lib/dry/configurable/instance_methods.rb
+++ b/lib/dry/configurable/instance_methods.rb
@@ -11,17 +11,11 @@ module Dry
     # @api private
     module Initializer
       # @api private
-      if RUBY_VERSION >= "2.7"
-        def initialize(*, **)
-          @config = Config.new(self.class._settings.dup)
-          super
-        end
-      else
-        def initialize(*)
-          @config = Config.new(self.class._settings.dup)
-          super
-        end
+      def initialize(*)
+        @config = Config.new(self.class._settings.dup)
+        super
       end
+      ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
     end
 
     # Instance-level API when `Dry::Configurable` is included in a class

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe Dry::Configurable, '.included' do
     end
 
     it_behaves_like 'configure'
+
+    context "required initialize parameters" do
+      let(:configurable_klass) do
+        Class.new do
+          include Dry::Configurable
+          def initialize(a, b:); end
+        end
+      end
+
+      it "passes the arguments through" do
+        expect(configurable_klass.new("a", b: "c").config).to be_a(Dry::Configurable::Config)
+      end
+    end
   end
 
   context 'when #finalize! is defined in configurable class' do


### PR DESCRIPTION
This fixes an ArgumentError that would have been raised for classes including `Dry::Configurable` whose `#initialize` has required keyword parameters.

This is required to convert the base `Hanami::Configuration` class to dry-configurable, since that class has the following `#initialize` (whose params signature I'd like to retain):

```ruby
def initialize(env:)
```