### PR TITLE
Remove implicit to_hash conversion from Config

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -79,7 +79,6 @@ module Dry
           .to_h
       end
       alias_method :to_h, :values
-      alias_method :to_hash, :values
 
       # @api private
       def finalize!

--- a/spec/integration/dry/configurable/config_spec.rb
+++ b/spec/integration/dry/configurable/config_spec.rb
@@ -46,12 +46,6 @@ RSpec.describe Dry::Configurable::Config do
       end
     end
 
-    it 'dumps itself into a hash' do
-      expect(Hash(klass.config)).to eql(
-        db: { user: 'root', pass: 'secret', ports: Set[123, 321] }
-      )
-    end
-
     it 'is used for equality' do
       expect(klass.config).to eql(klass.config.dup)
     end


### PR DESCRIPTION
This causes problems when passing config objects to methods with `**splat`-style "kwrest" keyword parameters, since it will result in the config object unintentionally being destructured into a hash.

I don't believe this `to_hash` behaviour is a critical aspect of what we're offering with dry-configurable. My feeling is that no one really expects a config object to be 100% substitutable with a hash, and getting a plain hash when required is still easy via `#to_h` or `#values`.

I've raised this PR because of failures in https://github.com/hanami/hanami/pull/1107 for the tests running against Ruby 2.6: we pass one config object to another configurable object, and it ends up being deconstructed into a Hash, which is not expected and causes failures when we then try to reference settings by their named methods.

