### PR TITLE
Add convenience method Dry::Configurable::Settings#replace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-eval_gemfile 'Gemfile.devtools'
+eval_gemfile "Gemfile.devtools"
 
 gemspec
 
 group :benchmarks do
-  gem 'benchmark-ips'
+  gem "benchmark-ips"
 end
 
 group :tools do
-  gem 'hotch'
-  gem 'pry-byebug', platform: :mri
+  gem "hotch"
+  gem "pry-byebug", platform: :mri
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
-desc 'Run all specs in spec directory'
+desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler/setup'
-require 'dry/configurable'
+require "bundler/setup"
+require "dry/configurable"
 
 begin
-  require 'pry-byebug'
+  require "pry-byebug"
   Pry.start
 rescue LoadError
-  require 'irb'
+  require "irb"
   IRB.start
 end

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -44,7 +44,7 @@ module Dry
 
         def merge(setting)
           settings = input.merge(setting.input)
-          Nested.new(name, input: settings, **options)
+          Nested.new(name, input: settings, **setting.options)
         end
 
         # @api private

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -69,6 +69,11 @@ module Dry
         evaluate if input_defined?
       end
 
+      def merge(setting)
+        input.merge(setting.input) if input_defined?
+        evaluate
+      end
+
       # @api private
       def input_defined?
         !input.equal?(Undefined)

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -42,6 +42,11 @@ module Dry
       class Nested < Setting
         CONSTRUCTOR = Config.method(:new)
 
+        def merge(setting)
+          settings = input.merge(setting.input)
+          Nested.new(name, input: settings, **options)
+        end
+
         # @api private
         def pristine
           with(input: input.pristine)
@@ -67,11 +72,6 @@ module Dry
         @options = options
 
         evaluate if input_defined?
-      end
-
-      def merge(setting)
-        input.merge(setting.input) if input_defined?
-        evaluate
       end
 
       # @api private

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -71,7 +71,7 @@ module Dry
       private
 
       def merge_setting(setting)
-        if elements[setting.name].is_a? Setting::Nested
+        if elements[setting.name].is_a?(Setting::Nested) && setting.is_a?(Setting::Nested)
           elements[setting.name].merge(setting)
         else
           setting

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -34,11 +34,15 @@ module Dry
       end
 
       def merge(settings)
+        unless settings.is_a? Dry::Configurable::Settings
+          raise ArgumentError, "settings must be a Dry::Configurable::Settings"
+        end
         settings.each do |setting|
           merge_setting(setting)
         end
       end
 
+      # @api private
       def merge_setting(setting)
         if key?(setting.name)
           elements[setting.name].merge(setting)

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -27,7 +27,7 @@ module Dry
         unless settings.is_a? Dry::Configurable::Settings
           raise ArgumentError, "settings must be a Dry::Configurable::Settings"
         end
-        
+
         settings.each do |setting|
           self << setting
         end

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -37,7 +37,7 @@ module Dry
         unless settings.is_a? Dry::Configurable::Settings
           raise ArgumentError, "settings must be a Dry::Configurable::Settings"
         end
-        
+
         settings.each do |setting|
           merge_setting(setting)
         end

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -37,6 +37,7 @@ module Dry
         unless settings.is_a? Dry::Configurable::Settings
           raise ArgumentError, "settings must be a Dry::Configurable::Settings"
         end
+        
         settings.each do |setting|
           merge_setting(setting)
         end

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -33,6 +33,20 @@ module Dry
         end
       end
 
+      def merge(settings)
+        settings.each do |setting|
+          merge_setting(setting)
+        end
+      end
+
+      def merge_setting(setting)
+        if key?(setting.name)
+          elements[setting.name].merge(setting)
+        else
+          self << setting
+        end
+      end
+
       # @api private
       def <<(setting)
         elements[setting.name] = setting

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -24,7 +24,10 @@ module Dry
       end
 
       def replace(settings)
-        raise ArgumentError, "settings must be a Dry::Configurable::Settings" unless settings.is_a? Dry::Configurable::Settings
+        unless settings.is_a? Dry::Configurable::Settings
+          raise ArgumentError, "settings must be a Dry::Configurable::Settings"
+        end
+        
         settings.each do |setting|
           self << setting
         end

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -23,6 +23,13 @@ module Dry
         initialize_elements(elements)
       end
 
+      def replace(settings)
+        raise ArgumentError, "settings must be a Dry::Configurable::Settings" unless settings.is_a? Dry::Configurable::Settings
+        settings.each do |setting|
+          self << setting
+        end
+      end
+
       # @api private
       def <<(setting)
         elements[setting.name] = setting

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -23,6 +23,14 @@ module Dry
         initialize_elements(elements)
       end
 
+      def replace(settings)
+        ensure_arguments(settings)
+
+        settings.dup.each do |setting|
+          self << setting
+        end
+      end
+
       def merge!(settings)
         merge(settings).each do |setting|
           self << setting

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -185,68 +185,6 @@ RSpec.describe Dry::Configurable, ".setting" do
 
     include_context "configurable behavior"
 
-    context "can be configured with another class's settings" do
-      let(:other_klass) do
-        Class.new do
-          extend Dry::Configurable
-        end
-      end
-
-      it "should deep merge" do
-        klass.setting :database do
-          setting :type, "postgresql"
-          setting :host, "remote"
-          setting :port, 12_345
-          setting :deep do
-            setting :one, 1
-            setting :two, 2
-          end
-        end
-
-        other_klass.setting :database do
-          setting :host, "localhost"
-          setting :port
-          setting :deep, 3
-        end
-
-        other_klass._settings.merge(klass._settings.dup)
-        expect(other_klass.config.database.host).to eql("localhost")
-        expect(other_klass.config.database.port).to eql(nil)
-        expect(other_klass.config.database.type).to eql("postgresql")
-        expect(other_klass.config.database.deep).to eql(3)
-      end
-
-      it "replaces with each" do
-        klass.setting :hello, "world"
-        klass._settings.each do |setting|
-          other_klass._settings << setting.dup
-        end
-        expect(other_klass.config.hello).to eql("world")
-      end
-
-      it "replaces with replace" do
-        klass.setting :hello, "world"
-        other_klass._settings.replace(klass._settings.dup)
-        expect(other_klass.config.hello).to eql("world")
-      end
-
-      it "deep replace" do
-        klass.setting :database do
-          setting :dsn, "localhost"
-        end
-
-        other_klass._settings.replace(klass._settings.dup)
-        expect(other_klass.config.database.dsn).to eql("localhost")
-      end
-
-      it "throws an error if the settings aren't Dry::Configurable::Settings" do
-        klass.setting :hello, "world"
-        expect { other_klass._settings.replace(klass) }.to raise_error do |error|
-          expect(error.class).to be(ArgumentError)
-        end
-      end
-    end
-
     context "with a subclass" do
       let(:subclass) do
         Class.new(klass)

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -185,14 +185,14 @@ RSpec.describe Dry::Configurable, ".setting" do
 
     include_context "configurable behavior"
 
-    context "can be configured with another class's settings" do 
-      let(:other_klass) do 
-        Class.new do 
+    context "can be configured with another class's settings" do
+      let(:other_klass) do
+        Class.new do
           extend Dry::Configurable
         end
       end
 
-      it "replaces with each" do 
+      it "replaces with each" do
         klass.setting :hello, "world"
         klass._settings.each do |setting|
           other_klass._settings << setting.dup
@@ -200,24 +200,24 @@ RSpec.describe Dry::Configurable, ".setting" do
         expect(other_klass.config.hello).to eql("world")
       end
 
-      it "replaces with replace" do 
-        klass.setting :hello, "world" 
+      it "replaces with replace" do
+        klass.setting :hello, "world"
         other_klass._settings.replace(klass._settings.dup)
         expect(other_klass.config.hello).to eql("world")
       end
 
-      it "deep replace" do 
+      it "deep replace" do
         klass.setting :database do
           setting :dsn, "localhost"
         end
 
         other_klass._settings.replace(klass._settings.dup)
-        expect(other_klass.config.database.dsn).to eql('localhost')
+        expect(other_klass.config.database.dsn).to eql("localhost")
       end
 
-      it "throws an error if the settings aren't Dry::Configurable::Settings" do 
+      it "throws an error if the settings aren't Dry::Configurable::Settings" do
         klass.setting :hello, "world"
-        expect{ other_klass._settings.replace(klass) }.to raise_error do |error|
+        expect { other_klass._settings.replace(klass) }.to raise_error do |error|
           expect(error.class).to be(ArgumentError)
         end
       end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -192,6 +192,30 @@ RSpec.describe Dry::Configurable, ".setting" do
         end
       end
 
+      it "should deep merge" do
+        klass.setting :database do
+          setting :type, "postgresql"
+          setting :host, "remote"
+          setting :port, 12_345
+          setting :deep do
+            setting :one, 1
+            setting :two, 2
+          end
+        end
+
+        other_klass.setting :database do
+          setting :host, "localhost"
+          setting :port
+          setting :deep, 3
+        end
+
+        other_klass._settings.merge(klass._settings.dup)
+        expect(other_klass.config.database.host).to eql("localhost")
+        expect(other_klass.config.database.port).to eql(nil)
+        expect(other_klass.config.database.type).to eql("postgresql")
+        expect(other_klass.config.database.deep).to eql(3)
+      end
+
       it "replaces with each" do
         klass.setting :hello, "world"
         klass._settings.each do |setting|

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -185,6 +185,44 @@ RSpec.describe Dry::Configurable, ".setting" do
 
     include_context "configurable behavior"
 
+    context "can be configured with another class's settings" do 
+      let(:other_klass) do 
+        Class.new do 
+          extend Dry::Configurable
+        end
+      end
+
+      it "replaces with each" do 
+        klass.setting :hello, "world"
+        klass._settings.each do |setting|
+          other_klass._settings << setting.dup
+        end
+        expect(other_klass.config.hello).to eql("world")
+      end
+
+      it "replaces with replace" do 
+        klass.setting :hello, "world" 
+        other_klass._settings.replace(klass._settings.dup)
+        expect(other_klass.config.hello).to eql("world")
+      end
+
+      it "deep replace" do 
+        klass.setting :database do
+          setting :dsn, "localhost"
+        end
+
+        other_klass._settings.replace(klass._settings.dup)
+        expect(other_klass.config.database.dsn).to eql('localhost')
+      end
+
+      it "throws an error if the settings aren't Dry::Configurable::Settings" do 
+        klass.setting :hello, "world"
+        expect{ other_klass._settings.replace(klass) }.to raise_error do |error|
+          expect(error.class).to be(ArgumentError)
+        end
+      end
+    end
+
     context "with a subclass" do
       let(:subclass) do
         Class.new(klass)

--- a/spec/integration/dry/configurable/settings_spec.rb
+++ b/spec/integration/dry/configurable/settings_spec.rb
@@ -10,6 +10,29 @@ RSpec.describe Dry::Configurable::Settings do
       end
     end
 
+    context "with replace" do
+      let(:other_klass) do
+        Class.new do
+          extend Dry::Configurable
+        end
+      end
+
+      it "should replace nested fields" do
+        klass.setting :database do
+          setting :host, "localhost"
+        end
+
+        other_klass.setting :database do
+          setting :type, "postgresql"
+        end
+        other_klass._settings.replace(klass._settings)
+        expect(other_klass.config.database.host).to eql("localhost")
+        expect { other_klass.config.database.type }.to raise_error do |error|
+          expect(error.class).to eql(NoMethodError)
+        end
+      end
+    end
+
     context "with merge" do
       let(:other_klass) do
         Class.new do

--- a/spec/integration/dry/configurable/settings_spec.rb
+++ b/spec/integration/dry/configurable/settings_spec.rb
@@ -96,6 +96,15 @@ RSpec.describe Dry::Configurable::Settings do
         expect(other_klass.config.database.dsn).to eql("localhost")
       end
 
+      it "shouldn't blow up when merging a non nested setting to a nested setting" do 
+        klass.setting :database, "hello"
+        other_klass.setting :database do
+          setting :dsn, "localhost"
+        end
+        other_klass._settings.merge!(klass._settings)
+        expect(other_klass.config.database).to eql("hello")
+      end
+
       it "should work when the config accessor has already be invoked" do
         klass.setting :database do
           setting :dsn, "localhost"

--- a/spec/integration/dry/configurable/settings_spec.rb
+++ b/spec/integration/dry/configurable/settings_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe Dry::Configurable::Settings do
+  context "can be configured with another class's settings" do
+    let(:klass) do
+      Class.new do
+        extend Dry::Configurable
+      end
+    end
+
+    context "with merge" do
+      let(:other_klass) do
+        Class.new do
+          extend Dry::Configurable
+        end
+      end
+
+      it "should override fields and return a Dry::Configurable::Settings" do
+        klass.setting :database do
+          setting :type, "postgresql"
+          setting :host, "remote"
+        end
+
+        other_klass.setting :database do
+          setting :host, "localhost"
+          setting :port, 54_321
+        end
+
+        settings = other_klass._settings.merge(klass._settings)
+
+        aggregate_failures do
+          expect(settings.class).to be(Dry::Configurable::Settings)
+          expect(settings[:database].input.entries.size).to eql(3)
+          expect(settings[:database].input[:type].default).to eql("postgresql")
+          expect(settings[:database].input[:host].default).to eql("remote")
+          expect(settings[:database].input[:port].default).to eql(54_321)
+        end
+
+        aggregate_failures do
+          expect(other_klass.config.database.host).to eql("localhost")
+          expect(other_klass.config.database.port).to eql(54_321)
+          expect { other_klass.config.database.type }.to raise_error do |error|
+            expect(error.class).to eql(NoMethodError)
+          end
+        end
+
+        aggregate_failures do
+          expect(klass.config.database.host).to eql("remote")
+          expect(klass.config.database.type).to eql("postgresql")
+          expect { klass.config.database.port }.to raise_error do |error|
+            expect(error.class).to eql(NoMethodError)
+          end
+        end
+      end
+    end
+
+    context "with merge!" do
+      let(:other_klass) do
+        Class.new do
+          extend Dry::Configurable
+        end
+      end
+
+      it "replaces undefined fields" do
+        klass.setting :hello, "world"
+        other_klass._settings.merge!(klass._settings)
+        expect(other_klass.config.hello).to eql("world")
+      end
+
+      it "replaces deep fields" do
+        klass.setting :database do
+          setting :dsn, "localhost"
+        end
+
+        other_klass._settings.merge!(klass._settings)
+        expect(other_klass.config.database.dsn).to eql("localhost")
+      end
+
+      it "throws an error if the settings aren't Dry::Configurable::Settings" do
+        klass.setting :hello, "world"
+        expect { other_klass._settings.merge!(klass) }.to raise_error do |error|
+          expect(error.class).to be(ArgumentError)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/dry/configurable/settings_spec.rb
+++ b/spec/integration/dry/configurable/settings_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe Dry::Configurable::Settings do
         end
       end
 
+      it "should override a block" do
+        klass.setting(:hello, "bar") { |w| w.chars.join("_") }
+        other_klass.setting(:hello, "fuzz") { |w| w.chars.join("-") }
+        expect(other_klass.config.hello).to eql("f-u-z-z")
+        other_klass._settings.merge!(klass._settings)
+        expect(other_klass.config.hello).to eql("b_a_r")
+      end
+
       it "replaces undefined fields" do
         klass.setting :hello, "world"
         other_klass._settings.merge!(klass._settings)
@@ -73,7 +81,6 @@ RSpec.describe Dry::Configurable::Settings do
         klass.setting :database do
           setting :dsn, "localhost"
         end
-
         other_klass._settings.merge!(klass._settings)
         expect(other_klass.config.database.dsn).to eql("localhost")
       end
@@ -85,6 +92,18 @@ RSpec.describe Dry::Configurable::Settings do
         other_klass.setting :database do
           setting :dsn, "remote"
         end
+        other_klass._settings.merge!(klass._settings)
+        expect(other_klass.config.database.dsn).to eql("localhost")
+      end
+
+      it "should work when the config accessor has already be invoked" do
+        klass.setting :database do
+          setting :dsn, "localhost"
+        end
+        other_klass.setting :database do
+          setting :dsn, "remote"
+        end
+        expect(other_klass.config.database.dsn).to eql("remote")
         other_klass._settings.merge!(klass._settings)
         expect(other_klass.config.database.dsn).to eql("localhost")
       end

--- a/spec/integration/dry/configurable/settings_spec.rb
+++ b/spec/integration/dry/configurable/settings_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Dry::Configurable::Settings do
         expect(other_klass.config.database.dsn).to eql("localhost")
       end
 
-      it "shouldn't blow up when merging a non nested setting to a nested setting" do 
+      it "shouldn't blow up when merging a non nested setting to a nested setting" do
         klass.setting :database, "hello"
         other_klass.setting :database do
           setting :dsn, "localhost"

--- a/spec/integration/dry/configurable/settings_spec.rb
+++ b/spec/integration/dry/configurable/settings_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe Dry::Configurable::Settings do
         expect(other_klass.config.database.dsn).to eql("localhost")
       end
 
+      it "overrides deep fields" do
+        klass.setting :database do
+          setting :dsn, "localhost"
+        end
+        other_klass.setting :database do
+          setting :dsn, "remote"
+        end
+        other_klass._settings.merge!(klass._settings)
+        expect(other_klass.config.database.dsn).to eql("localhost")
+      end
+
       it "throws an error if the settings aren't Dry::Configurable::Settings" do
         klass.setting :hello, "world"
         expect { other_klass._settings.merge!(klass) }.to raise_error do |error|


### PR DESCRIPTION
Hiya,
Really new to this project and dry-rb in general, so I don't expect to hit the mark on my first try, but this PR fixes #109 

I'm curious if this is the desired api, or if it would be easier to copy settings from another Dry::Configurable class or object without accessing what I am assuming to be a an internal var?

I was thinking..

```ruby
  class One
    extend Dry::Configurable
    setting :hello, "world"
  end

  class Two
    extend Dry::Configurable
    setting :hello, "bazz"
  end

  Two.clobber_config(One)
  
  One.config.hello #=> "World"
  Two.config.hello #=> "World"
```