### PR TITLE
Fix test suite after change in deprecation's uplevel value in dry-core

### DIFF
--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.name).to be(:user)
     expect(setting.value).to eql("root")
     logger.rewind
-    expect(logger.string).to match(/#{FileUtils.pwd}.*default value as positional argument to settings is deprecated/)
+    expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
   end
 
   it "compiles a setting with a reader set" do
@@ -71,7 +71,7 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.name).to be(:dsn)
     expect(setting.value).to eql("jdbc:sqlite")
     logger.rewind
-    expect(logger.string).to match(/#{FileUtils.pwd}.*constructor as a block is deprecated/)
+    expect(logger.string).to match(/constructor as a block is deprecated/)
   end
 
   it "compiles a nested list of settings" do


### PR DESCRIPTION
After the legit change made at dry-rb/dry-core#56, the test suite here
was failing because of a wrong assumption made before: our tests are
calling from the DSL object itself in contrast to the class extending
it. I.e., we can't rely on the default value of the `uplevel` parameter
as we're skipping one stack.

References #115