### PR TITLE
Properly support and deprecate default hash values provided as second positional argument to `setting` for Ruby 2.6 and 2.7

### DIFF
--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -27,10 +27,10 @@ module Dry
         instance_exec(&block) if block
       end
 
-      # Register a new setting node and compile it into a setting object
+      # Registers a new setting node and compile it into a setting object
       #
       # @see ClassMethods.setting
-      # @api public
+      # @api private
       # @return Setting
       def setting(name, default = Undefined, **options, &block)
         unless VALID_NAME.match?(name.to_s)

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -32,7 +32,7 @@ module Dry
       # @see ClassMethods.setting
       # @api private
       # @return Setting
-      def setting(name, default = Undefined, **options, &block)
+      def setting(name, default = Undefined, **options, &block) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
         unless VALID_NAME.match?(name.to_s)
           raise ArgumentError, "#{name} is not a valid setting name"
         end
@@ -45,6 +45,70 @@ module Dry
             uplevel: 2
           )
           options = options.merge(default: default)
+        end
+
+        if RUBY_VERSION < "3.0" &&
+           default == Undefined &&
+           (valid_opts, invalid_opts = valid_and_invalid_options(options)) &&
+           invalid_opts.any? &&
+           valid_opts.none?
+          # In Ruby 2.6 and 2.7, when a hash is given as the second positional argument
+          # (i.e. the hash is intended to be the setting's default value), and there are
+          # no other keyword arguments given, the hash is assigned to the `options`
+          # variable instead of `default`.
+          #
+          # For example, for this setting:
+          #
+          #   setting :hash_setting, {my_hash: true}
+          #
+          # We'll have a `default` of `Undefined` and an `options` of `{my_hash: true}`
+          #
+          # If any additional keyword arguments are provided, e.g.:
+          #
+          #   setting :hash_setting, {my_hash: true}, reader: true
+          #
+          # Then we'll have a `default` of `{my_hash: true}` and an `options` of `{reader:
+          # true}`, which is what we want.
+          #
+          # To work around that first case and ensure our (deprecated) backwards
+          # compatibility holds for Ruby 2.6 and 2.7, we extract all invalid options from
+          # `options`, and if there are no remaining valid options (i.e. if there were no
+          # keyword arguments given), then we can infer the invalid options to be a
+          # default hash value for the setting.
+          #
+          # This approach also preserves the behavior of raising an ArgumentError when a
+          # distinct hash is _not_ intentionally provided as the second positional
+          # argument (i.e. it's not enclosed in braces), and instead invalid keyword
+          # arguments are given alongside valid ones. So this setting:
+          #
+          #   setting :some_setting, invalid_option: true, reader: true
+          #
+          # Would raise an ArgumentError as expected.
+          #
+          # However, the one case we can't catch here is when invalid options are supplied
+          # without hash literal braces, but there are no other keyword arguments
+          # supplied. In this case, a setting like:
+          #
+          #   setting :hash_setting, my_hash: true
+          #
+          # Is parsed identically to the first case described above:
+          #
+          #   setting :hash_setting, {my_hash: true}
+          #
+          # So in both of these cases, the default value will become `{my_hash: true}`. We
+          # consider this unlikely to be a problem in practice, since users are not likely
+          # to be providing invalid options to `setting` and expecting them to be ignored.
+          # Additionally, the deprecation messages will make the new behavior obvious, and
+          # encourage the users to upgrade their setting definitions.
+
+          Dry::Core::Deprecations.announce(
+            "default value as positional argument to settings",
+            "Provide a `default:` keyword argument instead",
+            tag: "dry-configurable",
+            uplevel: 2
+          )
+
+          options = {default: invalid_opts}
         end
 
         if block && !block.arity.zero?
@@ -77,7 +141,14 @@ module Dry
         return if options.none?
 
         invalid_keys = options.keys - Setting::OPTIONS
+
         raise ArgumentError, "Invalid options: #{invalid_keys.inspect}" unless invalid_keys.empty?
+      end
+
+      # Returns a tuple of valid and invalid options hashes derived from the options hash
+      # given to the setting
+      def valid_and_invalid_options(options)
+        options.partition { |k, _| Setting::OPTIONS.include?(k) }.map(&:to_h)
       end
     end
   end

--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -32,6 +32,51 @@ RSpec.describe Dry::Configurable::DSL do
     expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
   end
 
+  it "compiles but deprecates giving a defalt hash value as a positional argument (without any keyword args)" do
+    # This test is necessary for behavior specific to Ruby 2.6 and 2.7
+
+    logger = StringIO.new
+    Dry::Core::Deprecations.set_logger!(logger)
+
+    setting = dsl.setting :default_options, {foo: "bar"}
+
+    expect(setting.name).to be(:default_options)
+    expect(setting.value).to eq(foo: "bar")
+    logger.rewind
+    expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
+
+    if RUBY_VERSION < "3.0"
+      logger = StringIO.new
+      Dry::Core::Deprecations.set_logger!(logger)
+
+      setting = dsl.setting :default_options, foo: "bar"
+
+      expect(setting.name).to be(:default_options)
+      expect(setting.value).to eq(foo: "bar")
+      logger.rewind
+      expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
+    end
+  end
+
+  it "compiles but deprecates giving a defalt hash value as a positional argument (with keyword args) " do
+    # This test is necessary for behavior specific to Ruby 2.6 and 2.7
+
+    logger = StringIO.new
+    Dry::Core::Deprecations.set_logger!(logger)
+    setting = dsl.setting :default_options, {foo: "bar"}, reader: true
+
+    expect(setting.name).to be(:default_options)
+    expect(setting.value).to eq(foo: "bar")
+    logger.rewind
+    expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
+  end
+
+  it "does not infer a default hash value when non-valid keyword arguments are mixed in with valid keyword arguments" do
+    # This test is necessary for behavior specific to Ruby 2.6 and 2.7
+
+    expect { dsl.setting :default_options, foo: "bar", reader: true }.to raise_error ArgumentError, "Invalid options: [:foo]"
+  end
+
   it "compiles a setting with a reader set" do
     setting = dsl.setting(:dsn, default: "sqlite", reader: true)
 


### PR DESCRIPTION
Before this change, if we defined a setting like this:

```ruby
setting :default_options, {foo: "bar"}
```

It would fail on Ruby 2.6 and 2.7 because inside `DSL#setting`, whose signature is this:

```
def setting(name, default = Undefined, **options, &block)
```

The `default` value remains as `Undefined`, and `options` becomes `{foo: "bar"}`, which then sees an exception raised inside `#ensure_valid_options` because (of course) they are not valid options for `setting`.

What we really want is for that hash provided as the second positional parameter to be assigned to `default`, and `options` to remain as `{}`.

---

Per the extended code comments included in the change, we take the following approach to handle this case:

In Ruby 2.6 and 2.7, when a hash is given as the second positional argument (i.e. the hash is intended to be the setting's default value), and there are no other keyword arguments given, the hash is assigned to the `options` variable instead of `default`.

For example, for this setting:

```ruby
setting :hash_setting, {my_hash: true}
```

We'll have a `default` of `Undefined` and an `options` of `{my_hash: true}`

If any additional keyword arguments are provided, e.g.:

```ruby
setting :hash_setting, {my_hash: true}, reader: true
```

Then we'll have a `default` of `{my_hash: true}` and an `options` of `{reader: true}`, which is what we want.

To work around that first case and ensure our (deprecated) backwards compatibility holds for Ruby 2.6 and 2.7, we extract all invalid options from `options`, and if there are no remaining valid options (i.e. if there were no keyword arguments given), then we can infer the invalid options to be a default hash value for the setting.

This approach also preserves the behavior of raising an ArgumentError when a distinct hash is _not_ intentionally provided as the second positional argument (i.e. it's not enclosed in braces), and instead invalid keyword arguments are given alongside valid ones. So this setting:

```ruby
setting :some_setting, invalid_option: true, reader: true
```

Would raise an ArgumentError as expected.

However, the one case we can't catch here is when invalid options are supplied without hash literal braces, but there are no other keyword arguments supplied. In this case, a setting like:

```ruby
setting :hash_setting, my_hash: true
```

Is parsed identically to the first case described above:

```ruby
setting :hash_setting, {my_hash: true}
```

So in both of these cases, the default value will become `{my_hash: true}`. We consider this unlikely to be a problem in practice, since users are not likely to be providing invalid options to `setting` and expecting them to be ignored. Additionally, the deprecation messages will make the new behavior obvious, and encourage the users to upgrade their setting definitions.