### PR TITLE
Fix spec match of `Dry::Configurable::DSL` deprecation warning for `default` and `constructor` arguments

### DIFF
--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.name).to be(:user)
     expect(setting.value).to eql("root")
     logger.rewind
-    expect(logger.string).to match(/#{FileUtils.pwd}.*default value as positional argument to settings is deprecated/)
+    expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
   end
 
   it "compiles a setting with a reader set" do
@@ -71,7 +71,7 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.name).to be(:dsn)
     expect(setting.value).to eql("jdbc:sqlite")
     logger.rewind
-    expect(logger.string).to match(/#{FileUtils.pwd}.*constructor as a block is deprecated/)
+    expect(logger.string).to match(/constructor as a block is deprecated/)
   end
 
   it "compiles a nested list of settings" do


### PR DESCRIPTION
By running the specs https://github.com/dry-rb/dry-configurable/commit/f44ea91a79f232c591f1d75de857d05dc1f29748 I get this [error](https://gist.github.com/jodosha/bfeb1953c8f7baab1479cf03e85c41bf).

This PR simplifies the RSpec expectation.