### PR TITLE
Add flags to control deprecation notices

### DIFF
--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/configurable/constants"
+require "dry/configurable/flags"
 require "dry/configurable/setting"
 require "dry/configurable/settings"
 require "dry/configurable/compiler"
@@ -32,18 +33,21 @@ module Dry
       # @see ClassMethods.setting
       # @api private
       # @return Setting
-      def setting(name, default = Undefined, **options, &block) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+      def setting(name, default = Undefined, **options, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         unless VALID_NAME.match?(name.to_s)
           raise ArgumentError, "#{name} is not a valid setting name"
         end
 
         if default != Undefined
-          Dry::Core::Deprecations.announce(
-            "default value as positional argument to settings",
-            "Provide a `default:` keyword argument instead",
-            tag: "dry-configurable",
-            uplevel: 2
-          )
+          if Dry::Configurable.warn_on_setting_positional_default
+            Dry::Core::Deprecations.announce(
+              "default value as positional argument to settings",
+              "Provide a `default:` keyword argument instead",
+              tag: "dry-configurable",
+              uplevel: 2
+            )
+          end
+
           options = options.merge(default: default)
         end
 
@@ -101,23 +105,28 @@ module Dry
           # Additionally, the deprecation messages will make the new behavior obvious, and
           # encourage the users to upgrade their setting definitions.
 
-          Dry::Core::Deprecations.announce(
-            "default value as positional argument to settings",
-            "Provide a `default:` keyword argument instead",
-            tag: "dry-configurable",
-            uplevel: 2
-          )
+          if Dry::Configurable.warn_on_setting_positional_default
+            Dry::Core::Deprecations.announce(
+              "default value as positional argument to settings",
+              "Provide a `default:` keyword argument instead",
+              tag: "dry-configurable",
+              uplevel: 2
+            )
+          end
 
           options = {default: invalid_opts}
         end
 
         if block && !block.arity.zero?
-          Dry::Core::Deprecations.announce(
-            "passing a constructor as a block",
-            "Provide a `constructor:` keyword argument instead",
-            tag: "dry-configurable",
-            uplevel: 2
-          )
+          if Dry::Configurable.warn_on_setting_constructor_block
+            Dry::Core::Deprecations.announce(
+              "passing a constructor as a block",
+              "Provide a `constructor:` keyword argument instead",
+              tag: "dry-configurable",
+              uplevel: 2
+            )
+          end
+
           options = options.merge(constructor: block)
           block = nil
         end

--- a/lib/dry/configurable/flags.rb
+++ b/lib/dry/configurable/flags.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "dry/core/class_attributes"
+
+module Dry
+  module Configurable
+    extend Core::ClassAttributes
+
+    # Set to false to suppress deprecation warning when a setting default is provided as a
+    # positional argument
+    defines :warn_on_setting_positional_default
+    warn_on_setting_positional_default true
+
+    # Set to false to suppress deprecation warning when a setting constructor is provided
+    # as a block
+    defines :warn_on_setting_constructor_block
+    warn_on_setting_constructor_block true
+  end
+end

--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe Dry::Configurable::DSL do
     expect(logger.string).to match(/default value as positional argument to settings is deprecated/)
   end
 
+  it "compiles when giving a default as positional argument, and suppresses the warning when flagged off" do
+    Dry::Configurable.warn_on_setting_positional_default false
+
+    logger = StringIO.new
+    Dry::Core::Deprecations.set_logger!(logger)
+    setting = dsl.setting :user, "root"
+
+    expect(setting.name).to be(:user)
+    expect(setting.value).to eql("root")
+    logger.rewind
+    expect(logger.string).to be_empty
+
+    Dry::Configurable.warn_on_setting_positional_default true
+  end
+
   it "compiles but deprecates giving a defalt hash value as a positional argument (without any keyword args)" do
     # This test is necessary for behavior specific to Ruby 2.6 and 2.7
 
@@ -58,7 +73,7 @@ RSpec.describe Dry::Configurable::DSL do
     end
   end
 
-  it "compiles but deprecates giving a defalt hash value as a positional argument (with keyword args) " do
+  it "compiles but deprecates giving a defalt hash value as a positional argument (with keyword args)" do
     # This test is necessary for behavior specific to Ruby 2.6 and 2.7
 
     logger = StringIO.new
@@ -117,6 +132,22 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.value).to eql("jdbc:sqlite")
     logger.rewind
     expect(logger.string).to match(/constructor as a block is deprecated/)
+  end
+
+  it "supports but deprecates giving a constructor as a block, and suppresses the warning when flagged off" do
+    Dry::Configurable.warn_on_setting_constructor_block false
+
+    logger = StringIO.new
+    Dry::Core::Deprecations.set_logger!(logger)
+
+    setting = dsl.setting(:dsn, default: "sqlite") { |value| "jdbc:#{value}" }
+
+    expect(setting.name).to be(:dsn)
+    expect(setting.value).to eql("jdbc:sqlite")
+    logger.rewind
+    expect(logger.string).to be_empty
+
+    Dry::Configurable.warn_on_setting_constructor_block true
   end
 
   it "compiles a nested list of settings" do


### PR DESCRIPTION
These can help temporarily reduce the noise for users of applications or gems still using the API deprecated in #111, #112, and #121.

We'll be releasing updates to all dependent gems in the dry-rb and Hanami ecosystems, but users may not be able to pull this in straightaway.