### PR TITLE
Allow settings to be defined and accessible after class-level `config` access

### DIFF
--- a/lib/dry/configurable/class_methods.rb
+++ b/lib/dry/configurable/class_methods.rb
@@ -13,12 +13,11 @@ module Dry
       include Methods
 
       # @api private
-      def inherited(klass)
+      def inherited(subclass)
         super
 
-        parent_settings = (respond_to?(:config) ? config._settings : _settings)
-
-        klass.instance_variable_set("@_settings", parent_settings)
+        subclass.instance_variable_set("@_settings", _settings.dup)
+        subclass.instance_variable_set("@_config", config.dup) if respond_to?(:config)
       end
 
       # Add a setting to the configuration
@@ -71,6 +70,11 @@ module Dry
       #
       # @api public
       def config
+        # The _settings provided to the Config remain shared between the class and the
+        # Config. This allows settings defined _after_ accessing the config to become
+        # available in subsequent accesses to the config. The config is duped when
+        # subclassing to ensure it remains distinct between subclasses and parent classes
+        # (see `.inherited` above).
         @config ||= Config.new(_settings)
       end
 

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -23,7 +23,7 @@ module Dry
 
       # @api private
       def initialize(settings)
-        @_settings = settings.dup
+        @_settings = settings
         @_resolved = Concurrent::Map.new
       end
 

--- a/lib/dry/configurable/instance_methods.rb
+++ b/lib/dry/configurable/instance_methods.rb
@@ -12,7 +12,11 @@ module Dry
     module Initializer
       # @api private
       def initialize(*)
+        # Dup settings at time of initializing to ensure setting values are specific to
+        # this instance. This does mean that any settings defined on the class _after_
+        # initialization will not be available on the instance.
         @config = Config.new(self.class._settings.dup)
+
         super
       end
       ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -62,9 +62,17 @@ module Dry
       def initialize(name, input: Undefined, default: Undefined, **options)
         @name = name
         @writer_name = :"#{name}="
+        @options = options
+
+        # Setting collections (see `Settings`) are shared between the configurable class
+        # and its `config` object, so for cloneable individual settings, we duplicate
+        # their _values_ as early as possible to ensure no impact from unintended mutation
         @input = input
         @default = default
-        @options = options
+        if cloneable?
+          @input = input.dup
+          @default = default.dup
+        end
 
         evaluate if input_defined?
       end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -45,12 +45,31 @@ RSpec.describe Dry::Configurable, ".setting" do
     end
 
     context "with a default value" do
-      before do
-        klass.setting :db, default: "sqlite"
+      context "string" do
+        before do
+          klass.setting :db, default: "sqlite"
+        end
+
+        it "presets the default value" do
+          expect(object.config.db).to eql("sqlite")
+        end
       end
 
-      it "presets the value with the default" do
-        expect(object.config.db).to eql("sqlite")
+      context "hash" do
+        it "returns the default value" do
+          klass.setting :db_config, default: {user: "root", password: ""}
+
+          expect(object.config.db_config).to eql(user: "root", password: "")
+        end
+
+        it "copies the original hash object" do
+          hash = {user: "root", password: ""}
+
+          klass.setting :db_config, default: hash
+
+          expect(object.config.db_config).to_not be(hash)
+          expect(object.config.db_config).to eql(hash)
+        end
       end
     end
 
@@ -166,21 +185,13 @@ RSpec.describe Dry::Configurable, ".setting" do
 
     include_context "configurable behavior"
 
-    context "class-level configurable behavior" do
-      specify "settings defined after accessing config are still available in the config" do
-        klass.setting :before, default: "defined before"
-        klass.config
-        klass.setting :after, default: "defined after"
+    specify "settings defined after accessing config are still available in the config" do
+      klass.setting :before, default: "defined before"
+      klass.config
+      klass.setting :after, default: "defined after"
 
-        expect(klass.config.before).to eq "defined before"
-        expect(klass.config.after).to eq "defined after"
-      end
-
-      specify "default values use their original objects" do
-        hash = {user: "root", password: ""}
-        klass.setting :db_config, default: hash
-        expect(object.config.db_config).to be(hash)
-      end
+      expect(klass.config.before).to eq "defined before"
+      expect(klass.config.after).to eq "defined after"
     end
 
     context "with a subclass" do


### PR DESCRIPTION
With this change, it's now possible to access the class-level `config` object and still have subsequently defined settings still available on the `config`. For example:

```ruby
class MyClass
  extend Dry::Configurable

  setting :foo, default: "foo"
  config
  setting :bar, default: "bar"
end

MyClass.config._settings.map(&:name) # => [:foo, :bar]

MyClass.config.bar = "new bar"
MyClass.config.bar # => "new bar"
```

Before this change, the `config._settings` list would have been just `[:foo]` and you would have received a `NoMethodError` when trying to call `config.bar=`.

This change works by having `Config` no longer eagerly `dup` the `settings` it receives when it initializes. This allows it to share the same object as the class-level `_settings` that receives new settings as they're defined.

We still ensure configurable subclasses have distinct settings and config by `dup`ing those objects at the time of subclassing.

We also ensure that configurable instances have distinct config by `dup`ing the settings at the time of initialization.

Originally, there were two incidental behavioral changes also introduced with this PR. The first _was_ that default values for settings were no longer eagerly duped when assigned, but with https://github.com/dry-rb/dry-configurable/pull/130/commits/a68c5f11e5263203103818a8860a3af66ee8801c I was able to preserve the existing behavior.

This leaves just the one incidental behavior change, demonstrated in the new `"configuring the parent after subclassing does not copy the config to the child"` spec example:

```ruby
specify "configuring the parent after subclassing does not copy the config to the child" do
  klass.setting :db

  subclass = Class.new(klass)

  object.config.db = "mariadb"

  expect(subclass.config.db).to be nil
end
```

In other words, if you:

1. Create a configurable parent class
2. Create a subclass
3. Change a config on that parent class
4. Then it will _not_ propagate to the child class

IMO, this actually feels like the right behavior versus what we had before, so I'm comfortable introducing it.

It's also more consistent with another closely-related existing test case, `"adding parent setting does not affect child"`, which follows the same pattern: create a configurable parent class, subclass it, do something to the parent class, do not expect it to flow through to the subclass.

---

The overall driver for this change is that it allows us to remove [this overloaded `setting` method](https://github.com/dry-rb/dry-system/blob/b7de4a9b4d9cb7bc2138a02847d6552a13eb2207/lib/dry/system/container.rb#L103-L113) from `Dry::System::Container`, an important in-ecosystem user of dry-configurable. See https://github.com/dry-rb/dry-system/pull/201 for this change in action.

Having dry-configurable serve this need out of the box for dry-system is a sign that this is a helpful change to be making for other users too, especially now while we're still pre-1.0 for dry-configurable.