### PR TITLE
Allow Hash as a possible config value

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -57,8 +57,11 @@ module Dry
       # @api public
       def update(values)
         values.each do |key, value|
-          case value
-          when Hash
+          if self[key].is_a?(self.class)
+            unless value.is_a?(Hash)
+              raise ArgumentError, "#{value.inspect} is not a valid setting value"
+            end
+
             self[key].update(value)
           else
             self[key] = value


### PR DESCRIPTION
It's handy to do something like
```ruby
v = {key: '"-----BEGIN RSA PRIVATE KEY-----…', key_password: 'qwerty'}
# and then
setting :openssl_key, constructor: ->(v) {
  OpenSSL::PKey.read(*v.values_at(:key, :key_password))
}
```
to have decrypted key in the settings instead of two strings, but dry-c complains that `nil` doesn't have `#update`. I suppose there is an expectation that if we're assigning a Hash — value is defined by `setting`, we shouldn't expect that.