### PR TITLE
Add memory usage benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem "dry-core", github: "dry-rb/dry-core", branch: "main"
 
 group :benchmarks do
   gem "benchmark-ips"
+  gem "benchmark-memory"
+
+  gem "hanami-utils"
 end
 
 group :tools do

--- a/benchmarks/memory.rb
+++ b/benchmarks/memory.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "benchmark/memory"
+
+def inherit_configurable(times)
+  require "dry/configurable"
+
+  klass = Class.new do
+    extend Dry::Configurable
+
+    setting :user, default: "jane"
+    setting :pass, default: "abcd"
+  end
+
+  times.times do
+    _subclass = Class.new(klass)
+  end
+end
+
+def inherit_configurable_nested(times)
+  require "dry/configurable"
+
+  klass = Class.new do
+    extend Dry::Configurable
+
+    setting :db do
+      setting :user, default: "jane"
+      setting :pass, default: "abcd"
+    end
+  end
+
+  times.times do
+    _subclass = Class.new(klass)
+  end
+end
+
+def inherit_dry_class_attributes(times)
+  require "dry/core/class_attributes"
+
+  klass = Class.new do
+    extend Dry::Core::ClassAttributes
+
+    defines :user, :pass
+
+    user "jane"
+    pass "abcd"
+  end
+
+  times.times do
+    _subclass = Class.new(klass)
+  end
+end
+
+def inherit_hanami_class_attributes(times)
+  require "hanami/utils/class_attribute"
+
+  klass = Class.new do
+    include Hanami::Utils::ClassAttribute
+
+    class_attribute :user, :pass
+
+    self.user = "jane"
+    self.pass = "abcd"
+  end
+
+  times.times do
+    _subclass = Class.new(klass)
+  end
+end
+
+def inherit_ordinary_class(times)
+  klass = Class.new
+
+  times.times do
+    _subclass = Class.new(klass)
+  end
+end
+
+times = Integer(ENV.fetch("TIMES", 100))
+
+Benchmark.memory do |x|
+  x.report("configurable") { inherit_configurable(times) }
+  x.report("configurable (nested)") { inherit_configurable_nested(times) }
+  x.report("dry-core class attributes") { inherit_dry_class_attributes(times) }
+  x.report("hanami-utils class attributes") { inherit_hanami_class_attributes(times) }
+  x.report("ordinary inheritance") { inherit_ordinary_class(times) }
+
+  x.compare!
+end


### PR DESCRIPTION
This compares the memory cost of inheritance from the following superclasses:

- dry-configurable using two top-level settings
- dry-configurable using the same two settings, just nested one level deeper
- dry-core class attributes
- hanami-utils class attributes
- a plain old Ruby class, serving as a "control" for the benchmark

You can run the benchmark via `bundle exec benchmarks/memory.rb`. You can also control the number of subclasses it creates by setting a `TIMES` var (which otherwise defaults to 100).

Twiddling with the number of subclasses yielded interesting results.

At 100 subclasses:

```
Calculating -------------------------------------
        configurable   742.714k memsize (    79.241k retained)
                         6.047k objects (   448.000  retained)
                        50.000  strings (    50.000  retained)
configurable (nested)
                       530.312k memsize (     0.000  retained)
                         6.690k objects (     0.000  retained)
                         8.000  strings (     0.000  retained)
dry-core class attributes
                        50.848k memsize (    80.000  retained)
                       114.000  objects (     2.000  retained)
                         2.000  strings (     1.000  retained)
hanami-utils class attributes
                       281.352k memsize (     2.440k retained)
                         2.517k objects (     8.000  retained)
                         6.000  strings (     0.000  retained)
ordinary inheritance    17.776k memsize (     0.000  retained)
                       101.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
ordinary inheritance:          17776 allocated
dry-core class attributes:     50848 allocated - 2.86x more
hanami-utils class attributes: 281352 allocated - 15.83x more
configurable (nested):         530312 allocated - 29.83x more
configurable:                  742714 allocated - 41.78x more
```

It’s surprising here that the non-nested configurable scenario allocated vastly more more objects than even the _nested_ version (which you would expected to have more, due to the need for an intermediary object to hold the nested config).

Also, the fact that the configurable allocates over 41x more memory than plain inheritance is certainly something!

It’s also interesting that hanami-utils’ class attributes are so much more ineffecient than dry-core’s implementation.

Then, at 10,000 subclasses:

```
Calculating -------------------------------------
        configurable    21.889M memsize (    79.241k retained)
                       243.647k objects (   448.000  retained)
                        50.000  strings (    50.000  retained)
configurable (nested)
                        52.248M memsize (     0.000  retained)
                       660.090k objects (     0.000  retained)
                         8.000  strings (     0.000  retained)
dry-core class attributes
                         4.803M memsize (    80.000  retained)
                        10.014k objects (     2.000  retained)
                         2.000  strings (     1.000  retained)
hanami-utils class attributes
                        27.845M memsize (     2.440k retained)
                       250.017k objects (     8.000  retained)
                         6.000  strings (     0.000  retained)
ordinary inheritance     1.760M memsize (     0.000  retained)
                        10.001k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
ordinary inheritance:          1760176 allocated
dry-core class attributes:     4802848 allocated - 2.73x more
configurable:                  21889114 allocated - 12.44x more
hanami-utils class attributes: 27844632 allocated - 15.82x more
configurable (nested):         52247912 allocated - 29.68x more
```

Here we see a reversal of the order of the configurable with/without nested setting scenarios. The nested scenario holds its ratio at 29x, but configurable drops from 41.78x (at 100 subclasses) to 12.44x (at 10,000).

The retain counts on the configurable scenario are also interesting. If I reverse the order of the "configurable" and "configurable (nested)" scenarios so the latter runs first, then _it’s_ that retains the objects:

```
configurable (nested)
                         1.057M memsize (    81.473k retained)
                        10.284k objects (   448.000  retained)
                        50.000  strings (    50.000  retained)
        configurable   219.000k memsize (     0.000  retained)
                         2.453k objects (     0.000  retained)
                         5.000  strings (     0.000  retained)
```

This must come from activating certain parts of our code for the first time.

Still, a cost of 80k to do so seems pretty steep.

---

Anyway, the goal with these benchmarks is to use them as a reference for some upcoming memory usage optimisation work here in dry-configurable. We could then look to establish something like this as a way to ensure any future changes we make here do not have undue effects on our memory consumption.