### PR TITLE
Use released dry-core without autoloading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-gem "dry-core", github: "dry-rb/dry-core", branch: "main"
-
 group :benchmarks do
   gem "benchmark-ips"
   gem "benchmark-memory"

--- a/dry-configurable.gemspec
+++ b/dry-configurable.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7.0"
 
   # to update dependencies edit project.yml
-  spec.add_runtime_dependency "dry-core", ">= 0.9"
+  spec.add_runtime_dependency "dry-core", "~> 0.6"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "bundler"

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -47,8 +47,6 @@ module Dry
   #
   # @api public
   module Configurable
-    include Dry::Core::Constants
-
     def self.loader
       @loader ||= Zeitwerk::Loader.new.tap do |loader|
         root = File.expand_path("..", __dir__)

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -48,6 +48,8 @@ module Dry
   #
   # @api public
   module Configurable
+    include Dry::Core::Constants
+
     def self.loader
       @loader ||= Zeitwerk::Loader.new.tap do |loader|
         root = File.expand_path("..", __dir__)

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -2,8 +2,7 @@
 
 require "zeitwerk"
 
-require "dry/core"
-
+require "dry/core/constants"
 require "dry/configurable/constants"
 require "dry/configurable/errors"
 require "dry/configurable/flags"

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -2,6 +2,8 @@
 
 require "dry/core/constants"
 
+require "dry/core/equalizer"
+
 module Dry
   module Configurable
     # Config exposes setting values through a convenient API

--- a/lib/dry/configurable/constants.rb
+++ b/lib/dry/configurable/constants.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/core/constants"
+
 module Dry
   # Shared constants
   #

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/core/deprecations"
+
 module Dry
   module Configurable
     # Setting DSL used by the class API

--- a/lib/dry/configurable/flags.rb
+++ b/lib/dry/configurable/flags.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/core/class_attributes"
+
 module Dry
   module Configurable
     extend Core::ClassAttributes

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -2,6 +2,8 @@
 
 require "set"
 
+require "dry/core/equalizer"
+
 module Dry
   module Configurable
     # This class represents a setting and is used internally.

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
+
 module Dry
   module Configurable
     # A settings map

--- a/project.yml
+++ b/project.yml
@@ -10,4 +10,4 @@ gemspec:
     - rspec
   runtime_dependencies:
     - [zeitwerk, "~> 2.6"]
-    - [dry-core, ">= 0.9"]
+    - [dry-core, "~> 0.6"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 
 require "dry/configurable"
 require "dry/configurable/test_interface"
+require "dry/core/deprecations"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!


### PR DESCRIPTION
In https://github.com/dry-rb/dry-validation/pull/714, @solnic asked for gems receiving updates to work with https://github.com/dry-rb/dry-configurable/pull/140 not also receive a dependency on the yet-to-be-released, zeitwerk-enabled dry-core (which right now, they're doing by virtue of dry-configurable’s main branch).

This PR reverts the dependency on dry-core’s zeitwerk-enabled main branch.

This helps us focus on getting this breaking dry-configurable release properly done, and then will let us focus on zeitwerk-enabling the rest of dry-rb afterwards.