### PR TITLE
Add Config#configured?

### DIFF
--- a/spec/integration/dry/configurable/config_spec.rb
+++ b/spec/integration/dry/configurable/config_spec.rb
@@ -14,6 +14,69 @@ RSpec.describe Dry::Configurable::Config do
     end
   end
 
+  describe "#configured?" do
+    it "returns false if the key has not been accessed" do
+      klass.setting :db
+      expect(klass.config.configured?(:db)).to be false
+    end
+
+    it "returns true if the key has been assigned" do
+      klass.setting :db
+      klass.config.db = "sqlite"
+      expect(klass.config.configured?(:db)).to be true
+    end
+
+    it "returns true when the key was assigned in a superclass" do
+      klass.setting :db
+      klass.config.db = "sqlite"
+      subclass = Class.new(klass)
+      expect(subclass.config.configured?(:db)).to be true
+    end
+
+    describe "assignable values" do
+      it "returns false if the key has been read" do
+        klass.setting :db
+        klass.config.db
+        expect(klass.config.configured?(:db)).to be false
+      end
+
+      it "returns false when the key was read in a superclass" do
+        klass.setting :db
+        klass.config.db
+        subclass = Class.new(klass)
+        expect(subclass.config.configured?(:db)).to be false
+      end
+    end
+
+    describe "cloneable values" do
+      it "returns false if the key has been read only" do
+        klass.setting :db, cloneable: true, default: []
+        klass.config.db
+        expect(klass.config.configured?(:db)).to be false
+      end
+
+      it "returns false if the key was read in a superclass" do
+        klass.setting :db, cloneable: true, default: []
+        klass.config.db
+        subclass = Class.new(klass)
+        expect(subclass.config.configured?(:db)).to be false
+      end
+
+      it "returns true if the value has been mutated" do
+        klass.setting :db, cloneable: true, default: []
+        klass.config.db << "sqlite"
+        expect(klass.config.configured?(:db)).to be true
+      end
+
+      it "returns true if the value was mutated in a superclass" do
+        klass.setting :db, cloneable: true, default: []
+        klass.config.db << "sqlite"
+        subclass = Class.new(klass)
+        expect(subclass.config.configured?(:db)).to be true
+      end
+    end
+  end
+
   describe "#update" do
     it "sets new config values in a flat config" do
       klass.setting :db


### PR DESCRIPTION
Stop capturing all values on read (capture mutable values only in this case) and use the internal `_values` hash to determine whether a value has been configured.

This is useful at least for dry-system, which has had to implement [its own version of this method](https://github.com/dry-rb/dry-system/blob/2c4b246fe6e35011be2214ba6575e9a1655c0e0f/lib/dry/system/config/component_dir.rb#L262-L272), so is likely also useful for others, too.

The reason I'm making this change now is because this dry-system implementation depended on the internal structures of the `Config` object, which were changed in #138, thereby breaking dry-system. It's better we make this feature part of dry-configurable's public API at this point.

This change does impose a slight performance cost at config value read time, in that default values may need to be re-run through a setting's constructor (if defined), but I expect this would be minimal in ordinary use. If this turns out to be problematic in practice, we could later cache these read-but-not-assigned values into a separate internal hash, so I'm confident to go ahead with this change. I've chosen not to do any additional optimisations for now in order to keep the implementation code simpler.