### PR TITLE
Share and read config via "superconfig"

### DIFF
--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -245,14 +245,14 @@ RSpec.describe Dry::Configurable, ".setting" do
         expect(subclass.config.db).to eql("mariadb")
       end
 
-      specify "configuring the parent after subclassing does not copy the config to the child" do
+      specify "configuring the parent after subclassing DOES copy the config to the child" do
         klass.setting :db
 
         subclass = Class.new(klass)
 
         object.config.db = "mariadb"
 
-        expect(subclass.config.db).to be nil
+        expect(subclass.config.db).to eq "mariadb"
       end
 
       it "not configured parent does not set child config" do


### PR DESCRIPTION
This PR takes @jodosha's experiments in https://gist.github.com/jodosha/b1c58a32e984e62df90e174b104de787 and https://gist.github.com/jodosha/b8b6409630db43962c79d1da92474caa and implements a working version of these within dry-configurable.

How I implemented these here is to give config instances an optional `superconfig` (i.e. the `config` from the parent configurable class). This gives us the same lookup to the "originals" from @jodosha's original gists.

However, there's one major change required for the implementation: **we need to dup mutable config values from the superconfig whenever they are read**. This is because we cannot differentiate reading from writing for mutable values. This would have been required in the original gists too, if they were expanded to satisfy all of our integration tests.

So this means that—for mutable values at least—we only really end up with one meaningful difference over the current implementation: whether to dup on inherit (per the main branch, with the work happening in `Config#dup_for_settings`) or dup on read (this PR, with the work happening in `Config#[]`).

The end result is that we don't actually net any meaningful memory improvements either.

I tested this with the following memory profiles:

- `TIMES=100 PROFILE=inherit_only bundle exec ruby benchmarks/memory_profile.rb`
- `TIMES=100 PROFILE=inherit_and_configure bundle exec ruby benchmarks/memory_profile.rb`

The results:

**Inherit only:**

```
main branch:
             Total allocated: 258091 bytes (1820 objects)
             Total retained:  102968 bytes (666 objects)
This branch:
             Total allocated: 260237 bytes (1853 objects)
             Total retained:  103161 bytes (670 objects)
```

**Inherit and configure:**

```
main branch:
             Total allocated: 299011 bytes (2410 objects)
             Total retained:  120288 bytes (766 objects)
This branch:
             Total allocated: 301197 bytes (2443 objects)
             Total retained:  120521 bytes (770 objects)
```

My take from this is that this approach would only really yield significant memory improvements in more constrained scenarios, and the implementation that achieves this wouldn't cover all the functionality we need for a fully working dry-configurable.