### PR TITLE
Share settings with subclasses where possible

### DIFF
--- a/lib/dry/configurable/class_methods.rb
+++ b/lib/dry/configurable/class_methods.rb
@@ -13,14 +13,15 @@ module Dry
 
         subclass.instance_variable_set(:@__config_extension__, __config_extension__)
 
-        new_settings = _settings.dup
-        subclass.instance_variable_set(:@_settings, new_settings)
+        # Share settings with subclasses until they define their own additional settings (see
+        # `.setting` below).
+        subclass.instance_variable_set(:@_settings, _settings)
 
         # Only classes **extending** Dry::Configurable have class-level config. When
         # Dry::Configurable is **included**, the class-level config method is undefined because it
         # resides at the instance-level instead (see `Configurable.included`).
         if respond_to?(:config)
-          subclass.instance_variable_set(:@config, config.dup_for_settings(new_settings))
+          subclass.instance_variable_set(:@config, config.dup)
         end
       end
 
@@ -42,6 +43,13 @@ module Dry
       # @api public
       def setting(*args, **options, &block)
         setting = __config_dsl__.setting(*args, **options, &block)
+
+        # If we're sharing settings with our superclass, create our own copy (along with a matching
+        # config copy) at the time of first new setting definition.
+        if superclass.respond_to?(:_settings) && _settings.eql?(superclass._settings)
+          @_settings = _settings.dup
+          @config = config.dup_for_settings(_settings) if respond_to?(:config)
+        end
 
         _settings << setting
 

--- a/lib/dry/configurable/class_methods.rb
+++ b/lib/dry/configurable/class_methods.rb
@@ -47,7 +47,7 @@ module Dry
         # If we're sharing settings with our superclass, create our own copy (along with a matching
         # config copy) at the time of first new setting definition.
         if superclass.respond_to?(:_settings) && _settings.eql?(superclass._settings)
-          @_settings = _settings.dup
+          @_settings = _settings.dup_for_child
           @config = config.dup_for_settings(_settings) if respond_to?(:config)
         end
 

--- a/lib/dry/configurable/class_methods.rb
+++ b/lib/dry/configurable/class_methods.rb
@@ -17,8 +17,8 @@ module Dry
         # `.setting` below).
         subclass.instance_variable_set(:@_settings, _settings)
 
-        # Only classes **extending** Dry::Configurable have class-level config. When
-        # Dry::Configurable is **included**, the class-level config method is undefined because it
+        # Only classes that **extend** Dry::Configurable have class-level `config`. When a class
+        # **includes** Dry::Configurable, the class-level `config` method is undefined because it
         # resides at the instance-level instead (see `Configurable.included`).
         if respond_to?(:config)
           subclass.instance_variable_set(:@config, config.dup)

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -130,7 +130,10 @@ module Dry
       #
       # @api public
       def values
-        _settings.to_h { |setting| [setting.name, self[setting.name]] }
+        # Ensure all settings are represented in values
+        _settings.each { |setting| self[setting.name] unless _values.key?(setting.name) }
+
+        _values
       end
 
       # Returns config values as a hash, with nested values also converted from {Config} instances

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -186,7 +186,7 @@ module Dry
       end
 
       def respond_to_missing?(meth, include_private = false)
-        _settings.key?(setting_name_from_method(meth)) || super
+        _settings[setting_name_from_method(meth)] || super
       end
 
       def setting_name_from_method(method_name)

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -99,7 +99,7 @@ module Dry
       #
       # @api public
       def configured?(key)
-        if _settings[key].cloneable? && _values.key?(key)
+        if _values.key?(key) && _settings[key].cloneable?
           return _values[key] != _settings[key].to_value
         end
 

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -36,6 +36,12 @@ module Dry
       end
 
       # @api private
+      private def initialize_copy(source)
+        super
+        @_values = source.__send__(:dup_values)
+      end
+
+      # @api private
       def dup_for_settings(settings)
         dup.tap { |config| config.instance_variable_set(:@_settings, settings) }
       end

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -23,6 +23,9 @@ module Dry
       attr_reader :default
 
       # @api private
+      attr_reader :cloneable
+
+      # @api private
       attr_reader :constructor
 
       # @api private
@@ -46,6 +49,9 @@ module Dry
       )
         @name = name
         @default = default
+        @cloneable = children.any? || options.fetch(:cloneable) {
+          Setting.cloneable_value?(default)
+        }
         @constructor = constructor
         @children = children
         @options = options
@@ -58,7 +64,7 @@ module Dry
 
       # @api private
       def cloneable?
-        children.any? || options.fetch(:cloneable) { Setting.cloneable_value?(default) }
+        cloneable
       end
 
       # @api private

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -19,9 +19,13 @@ module Dry
       attr_reader :settings
 
       # @api private
+      attr_reader :lookup_cache
+
+      # @api private
       def initialize(settings = EMPTY_ARRAY)
         @parent_settings = []
         @settings = settings.each_with_object({}) { |s, m| m[s.name] = s }
+        @lookup_cache = {}
       end
 
       # @api private
@@ -45,22 +49,15 @@ module Dry
 
       # @api private
       def [](name)
-        all_settings[name]
-      end
-
-      # @api private
-      def key?(name)
-        keys.include?(name)
-      end
-
-      # @api private
-      def keys
-        all_settings.keys
+        lookup_cache.fetch(name) {
+          lookup_cache[name] = all_settings[name]
+        }
       end
 
       # @api private
       def each(&block)
-        all_settings.each_value(&block)
+        parent_settings.each { |parent| parent.each_value(&block) }
+        settings.each_value(&block)
       end
 
       private

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -32,17 +32,23 @@ module Dry
       private def initialize_copy(source)
         @parent_settings = source.parent_settings.dup
         @settings = source.settings.dup
+        @lookup_cache = source.lookup_cache.dup
       end
 
       # @api private
       def dup_for_child
-        dup.tap do |child_settings|
-          child_settings.parent_settings << settings
-        end
+        dup.tap { |child| child.add_parent(settings) }
+      end
+
+      # @api private
+      def add_parent(parent)
+        # Use length for all_settings cache invalidation
+        parent_settings << [parent, parent.length]
       end
 
       # @api private
       def <<(setting)
+        @all_settings = nil # bit gross
         settings[setting.name] = setting
         self
       end
@@ -56,14 +62,27 @@ module Dry
 
       # @api private
       def each(&block)
-        parent_settings.each { |parent| parent.each_value(&block) }
-        settings.each_value(&block)
+        all_settings.each_value(&block)
       end
 
       private
 
       def all_settings
-        {**parent_settings.reduce({}, :merge), **settings}
+        if parent_settings.none?
+          settings
+        elsif @all_settings && parent_settings.all? { |(parent, cached_length)| parent.length == cached_length }
+          # Our cache is valid; no new parent settings have been defined since it was built
+          @all_settings
+        else
+          @all_settings = {}.tap { |hsh|
+            parent_settings.each_with_index do |(parent, _length), index|
+              parent_settings[index][1] = parent.length
+              hsh.merge!(parent)
+            end
+
+            hsh.merge!(settings)
+          }
+        end
       end
     end
   end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -227,14 +227,26 @@ RSpec.describe Dry::Configurable, ".setting" do
         expect(klass.config).not_to respond_to(:password)
       end
 
-      it "adding parent setting does not affect child" do
+      specify "adding a setting to a parent class makes that setting available to a child class" do
         klass.setting :db, default: "sqlite"
 
         expect(subclass.settings).to eql(Set[:db])
 
         klass.setting :other
 
+        expect(subclass.settings).to eql(Set[:db, :other])
+      end
+
+      specify "adding a setting to a parent class does not make that setting available to a child class that has already added its own settings" do
+        klass.setting :db, default: "sqlite"
+
         expect(subclass.settings).to eql(Set[:db])
+
+        subclass.setting :sub_setting
+
+        klass.setting :other
+
+        expect(subclass.settings).to eql(Set[:db, :sub_setting])
       end
 
       specify "configuring the parent before subclassing copies the config to the child" do

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Dry::Configurable, ".setting" do
         expect(subclass.settings).to eql(Set[:db, :other])
       end
 
-      specify "adding a setting to a parent class does not make that setting available to a child class that has already added its own settings" do
+      specify "adding a setting to a parent class does makes that setting available to a child class, even if when the child class has already defined its own settings" do
         klass.setting :db, default: "sqlite"
 
         expect(subclass.settings).to eql(Set[:db])
@@ -246,7 +246,7 @@ RSpec.describe Dry::Configurable, ".setting" do
 
         klass.setting :other
 
-        expect(subclass.settings).to eql(Set[:db, :sub_setting])
+        expect(subclass.settings).to eql(Set[:db, :other, :sub_setting])
       end
 
       specify "configuring the parent before subclassing copies the config to the child" do


### PR DESCRIPTION
When a configurable class is inherited, do not eagerly create a dup of the `_settings` collection, and instead share the same collection with the subclass. Then, if that subclass define new settings, create a new `_settings` collection in place (along with a new matching `config` object referring to the new settings).

This change improves memory usage for the (quite common) scenario of many subclasses inheriting from a single class that contains all `setting` definitions.

For our `benchmarks/memory_profile.rb` with 10,000 subclasses inheriting from a single parent class that defines 3 settings (`TIMES=10000 PROFILE=inherit_only bundle exec ruby benchmarks/memory_profile.rb`), this exhibits the following memory usage:

```
Total allocated: 5765254 bytes (31228 objects)
Total retained:  5626120 bytes (30165 objects)
```

For the main branch, this is currently:

```
Total allocated: 9524491 bytes (61220 objects)
Total retained:  7706168 bytes (50166 objects)
```

**This is a 39.5% decrease in allocated memory for a large collection of subclasses (9.52 MB down to 5.77 MB).**

This change does have a couple of quirks, however:

- If you're inheriting from a configurable class and then capturing the `subclass.config` to a variable, and _then_ defining a new setting after, then the new `subclass.config` will be different to the one just captured.

  I do feel this is a reasonable tradeoff given the memory usage improvements. We should encourage our users to see `.config` (and `._settings`) as properties of the configurable class with their own opaque lifecycles; they should be accessed directly off the configurable class whenever needed.
- There is one behavioural change, in that a setting class defined in a parent class will also be visible to any subclasses even if those subclasses were made before the time of setting definition. Previously, settings from parent classes were only visible if they were defined before subclassing.

Overall, since this change considerably improves memory usage for our most common kind of usage (one or two parent classes with setting definitions, many subclasses without), I think it would be worth finding a way to get this in.

