### PR TITLE
Restore Config value read performance

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -130,7 +130,10 @@ module Dry
       #
       # @api public
       def values
-        _settings.to_h { |setting| [setting.name, self[setting.name]] }
+        # Ensure all settings are represented in values
+        _settings.each { |setting| self[setting.name] unless _values.key?(setting.name) }
+
+        _values
       end
 
       # Returns config values as a hash, with nested values also converted from {Config} instances

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -99,7 +99,7 @@ module Dry
       #
       # @api public
       def configured?(key)
-        if _settings[key].cloneable? && _values.key?(key)
+        if _values.key?(key) && _settings[key].cloneable?
           return _values[key] != _settings[key].to_value
         end
 

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -23,6 +23,9 @@ module Dry
       attr_reader :default
 
       # @api private
+      attr_reader :cloneable
+
+      # @api private
       attr_reader :constructor
 
       # @api private
@@ -46,6 +49,9 @@ module Dry
       )
         @name = name
         @default = default
+        @cloneable = children.any? || options.fetch(:cloneable) {
+          Setting.cloneable_value?(default)
+        }
         @constructor = constructor
         @children = children
         @options = options
@@ -58,7 +64,7 @@ module Dry
 
       # @api private
       def cloneable?
-        children.any? || options.fetch(:cloneable) { Setting.cloneable_value?(default) }
+        cloneable
       end
 
       # @api private


### PR DESCRIPTION
Restore the performance of `Config` on value reads back to its state before #143.

Here we capture all values on read to `Config`'s internal `_values` hash. This means that after first read, all subsequent reads should be fast (This is how it was before #143).

Then to preserve the functionality of `#configured?` that we introduced in #143, we keep a separate `_configured` Set that tracks the names of values that have either been assigned, or mutable values that have been read. For the very small amount of memory (one set per config object, since most of the names, as symbols, should already be in memory) this is a worthwhile tradeoff for the best possible performance on read, which should reasonably be expected by our users to be as fast as possible.