### PR TITLE
Memoize `Config#hash` on finalize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ end
 group :tools do
   gem "hotch", platform: :mri
   gem "pry-byebug", platform: :mri
+  gem "rspec-benchmark"
 end

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -128,6 +128,16 @@ module Dry
       end
 
       # @api private
+      alias_method :_dry_equalizer_hash, :hash
+
+      # @api public
+      def hash
+        return @__hash__ if instance_variable_defined?(:@__hash__)
+
+        _dry_equalizer_hash
+      end
+
+      # @api private
       def finalize!(freeze_values: false)
         values.each_value do |value|
           if value.is_a?(self.class)
@@ -136,6 +146,13 @@ module Dry
             value.freeze
           end
         end
+
+        # Memoize the hash for the object when finalizing (regardless of whether values themselves
+        # are to be frozen; the intention of finalization is that no further changes should be
+        # made). The benefit of freezing the hash at this point is that it saves repeated expensive
+        # computation (through Dry::Equalizer's hash implementation) if that hash is to be used
+        # later in performance-sensitive situations, such as when serving as a cache key or similar.
+        @__hash__ = _dry_equalizer_hash unless frozen?
 
         freeze
       end

--- a/spec/integration/dry/configurable/config_spec.rb
+++ b/spec/integration/dry/configurable/config_spec.rb
@@ -239,6 +239,28 @@ RSpec.describe Dry::Configurable::Config do
     end
   end
 
+  describe "#hash" do
+    it "returns the integer hash value for the convig based on its values" do
+      klass.setting :db
+
+      expect(klass.config.hash).to be_an_instance_of(Integer)
+      expect { klass.config.db = "sqlite" }.to change { klass.config.hash }
+    end
+
+    it "is memoized when the config is finalized", :performance do
+      klass.setting :a
+      klass.setting :b
+      klass.setting :c
+      klass.setting :d
+      klass.setting :e
+
+      finalized_config = klass.config.dup.finalize!
+
+      expect(finalized_config.hash).to eq klass.config.hash
+      expect { finalized_config.hash }.to perform_faster_than { klass.config.hash }.at_least(50).times
+    end
+  end
+
   describe "#method_missing" do
     it "provides access to reader methods" do
       klass.setting :hello

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require_relative "support/coverage"
 require "pathname"
+require "rspec-benchmark"
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 
@@ -21,6 +22,8 @@ require "dry/core/deprecations"
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.filter_run_when_matching :focus
+
+  config.include RSpec::Benchmark::Matchers
 
   config.around do |example|
     module Test


### PR DESCRIPTION
Freezing the hash is beneficial at this point because it saves repeated expensive computation if that hash is to be used later in performance-sensitive situations, such as when serving as a cache key or similar.

The reason we do this here is because Dry::Equalizer's hash implementation is always dynamic, i.e. it will recompute the hash every time from the config's full `values`. Dry::Equalizer does provide an `immutable: true` option to memoize the hash, but we can't use that for `Config` because it is intended to be mutable for much of its lifecycle. 

However, there is one point in `Config`'s lifecycle at which we know its values should no longer change, which is `#finalize!`. By using this as an opportunity to memoize the hash, it will allow users that rely on this hash to trust that it can be used in more performance sensitive situations, such as using it as a cache key.

In terms of testing this, I've brought in rspec-benchmarks and added a test to verify that `#hash` on a finalized config is significantly faster than on a non-finalized config:

```ruby
    it "is memoized when the config is finalized", :performance do
      klass.setting :a
      klass.setting :b
      klass.setting :c
      klass.setting :d
      klass.setting :e

      finalized_config = klass.config.dup.finalize!

      expect(finalized_config.hash).to eq klass.config.hash
      expect { finalized_config.hash }.to perform_faster_than { klass.config.hash }.at_least(50).times
    end
```

This test does take around 300ms to run, but it is the best way I could think of to exercise this behaviour (e.g. it's much more meaningful IMO than simply asserting that a `@__hash__` ivar exists).

---

Sidenote: config being used as a hash key is what actually happens in dry-view/hanami-view, and this PR is an effort to make dry-configurable more useful in those situations. See https://github.com/dry-rb/dry-view/pull/156 as an effort to work around the issue directly inside dry-view. My preferred approach to solve this for dry-view would be to bring the hash memoizing into dry-configurable, where it can be more appropriately managed alongside the rest of the `Config` logic, and then in dry-view, automatically finalise the `config` the first time a view instance is initialised.