### PR TITLE
Rename `_settings` class method to `settings`

### DIFF
--- a/lib/dry/configurable/class_methods.rb
+++ b/lib/dry/configurable/class_methods.rb
@@ -13,7 +13,7 @@ module Dry
 
         subclass.instance_variable_set(:@__config_extension__, __config_extension__)
 
-        new_settings = _settings.dup
+        new_settings = settings.dup
         subclass.instance_variable_set(:@_settings, new_settings)
 
         # Only classes **extending** Dry::Configurable have class-level config. When
@@ -43,28 +43,19 @@ module Dry
       def setting(*args, **options, &block)
         setting = __config_dsl__.setting(*args, **options, &block)
 
-        _settings << setting
+        settings << setting
 
         __config_reader__.define(setting.name) if setting.reader?
 
         self
       end
 
-      # Return declared settings
-      #
-      # @return [Set<Symbol>]
-      #
-      # @api public
-      def settings
-        Set[*_settings.map(&:name)]
-      end
-
-      # Return declared settings
+      # Returns the defined settings for the class.
       #
       # @return [Settings]
       #
       # @api public
-      def _settings
+      def settings
         @_settings ||= Settings.new
       end
 
@@ -78,7 +69,7 @@ module Dry
       end
 
       # @api private
-      def __config_build__(settings = _settings)
+      def __config_build__(settings = self.settings)
         __config_extension__.config_class.new(settings)
       end
 

--- a/lib/dry/configurable/instance_methods.rb
+++ b/lib/dry/configurable/instance_methods.rb
@@ -12,7 +12,7 @@ module Dry
     module Initializer
       # @api private
       def initialize(*)
-        @config = self.class.__config_build__(self.class._settings)
+        @config = self.class.__config_build__(self.class.settings)
 
         super
       end

--- a/lib/dry/configurable/setting.rb
+++ b/lib/dry/configurable/setting.rb
@@ -4,9 +4,9 @@ require "set"
 
 module Dry
   module Configurable
-    # This class represents a setting and is used internally.
+    # A defined setting.
     #
-    # @api private
+    # @api public
     class Setting
       include Dry::Equalizer(:name, :default, :constructor, :children, :options, inspect: false)
 
@@ -16,22 +16,22 @@ module Dry
 
       CLONEABLE_VALUE_TYPES = [Array, Hash, Set, Config].freeze
 
-      # @api private
+      # @api public
       attr_reader :name
 
-      # @api private
+      # @api public
       attr_reader :default
 
-      # @api private
+      # @api public
       attr_reader :cloneable
 
-      # @api private
+      # @api public
       attr_reader :constructor
 
-      # @api private
+      # @api public
       attr_reader :children
 
-      # @api private
+      # @api public
       attr_reader :options
 
       # @api private
@@ -62,7 +62,7 @@ module Dry
         options[:reader].equal?(true)
       end
 
-      # @api private
+      # @api public
       def cloneable?
         cloneable
       end

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -2,7 +2,7 @@
 
 module Dry
   module Configurable
-    # A settings map
+    # A collection of defined settings on a given class.
     #
     # @api private
     class Settings
@@ -19,35 +19,46 @@ module Dry
       end
 
       # @api private
+      private def initialize_copy(source)
+        @settings = source.settings.dup
+      end
+
+      # @api private
       def <<(setting)
         settings[setting.name] = setting
         self
       end
 
-      # @api private
+      # Returns the setting for the given name, if found.
+      #
+      # @return [Setting, nil] the setting, or nil if not found
+      #
+      # @api public
       def [](name)
         settings[name]
       end
 
-      # @api private
+      # Returns true if a setting for the given name is defined.
+      #
+      # @return [Boolean]
+      #
+      # @api public
       def key?(name)
         keys.include?(name)
       end
 
-      # @api private
+      # Returns the list of defined setting names.
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api public
       def keys
         settings.keys
       end
 
-      # @api private
+      # @api public
       def each(&block)
         settings.each_value(&block)
-      end
-
-      private
-
-      def initialize_copy(source)
-        @settings = source.settings.dup
       end
     end
   end

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -230,11 +230,11 @@ RSpec.describe Dry::Configurable, ".setting" do
       it "adding parent setting does not affect child" do
         klass.setting :db, default: "sqlite"
 
-        expect(subclass.settings).to eql(Set[:db])
+        expect(subclass.settings.map(&:name)).to eql([:db])
 
         klass.setting :other
 
-        expect(subclass.settings).to eql(Set[:db])
+        expect(subclass.settings.map(&:name)).to eql([:db])
       end
 
       specify "configuring the parent before subclassing copies the config to the child" do
@@ -273,12 +273,12 @@ RSpec.describe Dry::Configurable, ".setting" do
           config.nested.test = "woah!"
         end
 
-        expect(klass.settings).to eql(Set[:db, :nested])
+        expect(klass.settings.map(&:name)).to eq([:db, :nested])
         expect(object.config.db).to eql("sqlite")
         expect(object.config.db).to eql("sqlite")
         expect(object.config.nested.test).to eql("hello")
 
-        expect(subclass.settings).to eql(Set[:db, :nested])
+        expect(subclass.settings.map(&:name)).to eq([:db, :nested])
         expect(subclass.config.db).to eql("postgresql")
         expect(subclass.config.nested.test).to eql("woah!")
       end


### PR DESCRIPTION
This gives us a "neater" name for the second (after `config`) main way of interacting with configurable classes. It's also better match with the `setting` method we use for defining new settings in the first place.

This method was previously `_settings` because we had already had the `settings` name taken by the method that returns a set of setting names only. However, these names can be just as easily accessed via the `#name` attribute on individual settings themselves, and reducing our overall surface area here will help make the settings side of our API easier to understand and use.

Along with this change, I've made a range of methods `@api public` for the first time, on both `Settings` and `Setting`, since these are the objects returned by `.settings`. This is more a reflection of real usage than a big change, however, since I expect we would have had users already interacting with these objects given that the previous `._settings` method was itself already marked as `@api public`.

**This is a breaking change**, though easy to correct (change `.settings` in user code to `.settings.map(&:name)`.