### PR TITLE
Exit from `Config#finalize!` if already frozen

### DIFF
--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -68,7 +68,7 @@ module Dry
       # @param [String,Symbol] name
       # @param [Object] value
       def []=(name, value)
-        raise FrozenConfig, "Cannot modify frozen config" if frozen?
+        raise FrozenConfigError, "Cannot modify frozen config" if frozen?
 
         name = name.to_sym
 

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -156,8 +156,10 @@ module Dry
         _dry_equalizer_hash
       end
 
-      # @api private
+      # @api public
       def finalize!(freeze_values: false)
+        return self if frozen?
+
         values.each_value do |value|
           if value.is_a?(self.class)
             value.finalize!(freeze_values: freeze_values)
@@ -171,7 +173,7 @@ module Dry
         # made). The benefit of freezing the hash at this point is that it saves repeated expensive
         # computation (through Dry::Equalizer's hash implementation) if that hash is to be used
         # later in performance-sensitive situations, such as when serving as a cache key or similar.
-        @__hash__ = _dry_equalizer_hash unless frozen?
+        @__hash__ = _dry_equalizer_hash
 
         freeze
       end

--- a/lib/dry/configurable/errors.rb
+++ b/lib/dry/configurable/errors.rb
@@ -6,7 +6,8 @@ module Dry
   # @api public
   module Configurable
     Error = Class.new(::StandardError)
-    AlreadyIncluded = ::Class.new(Error)
-    FrozenConfig = ::Class.new(Error)
+
+    AlreadyIncludedError = Class.new(Error)
+    FrozenConfigError = Class.new(Error)
   end
 end

--- a/lib/dry/configurable/extension.rb
+++ b/lib/dry/configurable/extension.rb
@@ -26,7 +26,7 @@ module Dry
 
       # @api private
       def included(klass)
-        raise AlreadyIncluded if klass.include?(InstanceMethods)
+        raise AlreadyIncludedError if klass.include?(InstanceMethods)
 
         super
 

--- a/lib/dry/configurable/methods.rb
+++ b/lib/dry/configurable/methods.rb
@@ -8,7 +8,7 @@ module Dry
     module Methods
       # @api public
       def configure(&block)
-        raise FrozenConfig, "Cannot modify frozen config" if frozen?
+        raise FrozenConfigError, "Cannot modify frozen config" if frozen?
 
         yield(config) if block
         self

--- a/lib/dry/configurable/methods.rb
+++ b/lib/dry/configurable/methods.rb
@@ -8,7 +8,7 @@ module Dry
     module Methods
       # @api public
       def configure(&block)
-        raise FrozenConfigError, "Cannot modify frozen config" if frozen?
+        raise FrozenConfigError, "Cannot modify frozen config" if config.frozen?
 
         yield(config) if block
         self

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dry::Configurable, ".included" do
     it "raises when Dry::Configurable has already been included" do
       expect {
         configurable_klass.include(Dry::Configurable)
-      }.to raise_error(Dry::Configurable::AlreadyIncluded)
+      }.to raise_error(Dry::Configurable::AlreadyIncludedError)
     end
 
     it "ensures `.config` is not defined" do

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -398,6 +398,14 @@ RSpec.describe Dry::Configurable, ".setting" do
       expect(object_2.config.after).to eq "defined after"
     end
 
+    it "is frozen when finalized" do
+      object.finalize!
+      object.finalize! # second call becomes a no op
+
+      expect(object).to be_frozen
+      expect(object.config).to be_frozen
+    end
+
     shared_examples "copying" do
       before do
         klass.setting :env
@@ -447,41 +455,6 @@ RSpec.describe Dry::Configurable, ".setting" do
       end
 
       expect(object.config.db).to eql("mariadb")
-    end
-
-    it "can be finalized" do
-      klass.setting :kafka, default: "kafka://127.0.0.1:9092"
-
-      object.finalize!
-      # becomes a no-op
-      object.finalize!
-
-      expect(object).to be_frozen
-      expect(object.config.db).to be_frozen
-      expect(object.config.db.user).not_to be_frozen
-
-      object.config.db.user << "foo"
-      expect(object.config.db.user).to eq("rootfoo")
-
-      # does not allow configure block anymore
-      expect { object.configure {} }.to raise_error(Dry::Configurable::FrozenConfigError)
-    end
-
-    it "can be finalized with freezing values" do
-      klass.setting :kafka, default: "kafka://127.0.0.1:9092"
-
-      object.finalize!(freeze_values: true)
-      # becomes a no-op
-      object.finalize!(freeze_values: true)
-
-      expect(object).to be_frozen
-      expect(object.config.db).to be_frozen
-      expect(object.config.db.user).to be_frozen
-
-      expect { object.config.db.user << "foo" }.to raise_error(FrozenError)
-
-      # does not allow configure block anymore
-      expect { object.configure {} }.to raise_error(Dry::Configurable::FrozenConfigError)
     end
 
     it "defines a reader shortcut for nested config" do

--- a/spec/integration/dry/configurable/setting_spec.rb
+++ b/spec/integration/dry/configurable/setting_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe Dry::Configurable, ".setting" do
       expect(object.config.db.user).to eq("rootfoo")
 
       # does not allow configure block anymore
-      expect { object.configure {} }.to raise_error(Dry::Configurable::FrozenConfig)
+      expect { object.configure {} }.to raise_error(Dry::Configurable::FrozenConfigError)
     end
 
     it "can be finalized with freezing values" do
@@ -481,7 +481,7 @@ RSpec.describe Dry::Configurable, ".setting" do
       expect { object.config.db.user << "foo" }.to raise_error(FrozenError)
 
       # does not allow configure block anymore
-      expect { object.configure {} }.to raise_error(Dry::Configurable::FrozenConfig)
+      expect { object.configure {} }.to raise_error(Dry::Configurable::FrozenConfigError)
     end
 
     it "defines a reader shortcut for nested config" do


### PR DESCRIPTION
This saves the work of attempting to finalize every nested config (or attempt to freeze again every value) if `finalize!` is called a second time.

This does make `finalize!` a one-shot operation, i.e. you can't call `finalize!` first, followed by `finalize!(freeze_values: true)`, but doing this would not be expected usage.

Also: rename error classes:

- `Dry::Configurable::AlreadyIncluded` -> `AlreadyIncludedError`
- `Dry::Configurable::FrozenConfig` -> `FrozenConfigError`