### PR TITLE
Dunderscore mixed in ivar names to ensure no clashes with user-set vars

### DIFF
--- a/lib/dry/configurable/class_methods.rb
+++ b/lib/dry/configurable/class_methods.rb
@@ -14,13 +14,13 @@ module Dry
         subclass.instance_variable_set(:@__config_extension__, __config_extension__)
 
         new_settings = settings.dup
-        subclass.instance_variable_set(:@_settings, new_settings)
+        subclass.instance_variable_set(:@__settings__, new_settings)
 
         # Only classes **extending** Dry::Configurable have class-level config. When
         # Dry::Configurable is **included**, the class-level config method is undefined because it
         # resides at the instance-level instead (see `Configurable.included`).
         if respond_to?(:config)
-          subclass.instance_variable_set(:@config, config.dup_for_settings(new_settings))
+          subclass.instance_variable_set(:@__config__, config.dup_for_settings(new_settings))
         end
       end
 
@@ -56,7 +56,7 @@ module Dry
       #
       # @api public
       def settings
-        @_settings ||= Settings.new
+        @__settings__ ||= Settings.new
       end
 
       # Return configuration
@@ -65,7 +65,7 @@ module Dry
       #
       # @api public
       def config
-        @config ||= __config_build__
+        @__config__ ||= __config_build__
       end
 
       # @api private

--- a/lib/dry/configurable/instance_methods.rb
+++ b/lib/dry/configurable/instance_methods.rb
@@ -12,7 +12,7 @@ module Dry
     module Initializer
       # @api private
       def initialize(*)
-        @config = self.class.__config_build__(self.class.settings)
+        @__config__ = self.class.__config_build__(self.class.settings)
 
         super
       end
@@ -30,7 +30,9 @@ module Dry
       # @return [Config]
       #
       # @api public
-      attr_reader :config
+      def config
+        @__config__
+      end
 
       # Finalize the config and freeze the object
       #
@@ -45,7 +47,7 @@ module Dry
       # @api public
       def initialize_copy(source)
         super
-        @config = source.config.dup
+        @__config__ = source.config.dup
       end
     end
   end

--- a/lib/dry/configurable/test_interface.rb
+++ b/lib/dry/configurable/test_interface.rb
@@ -10,7 +10,7 @@ module Dry
       #
       # @api public
       def reset_config
-        @config = config.pristine
+        @__config__ = config.pristine
       end
     end
 


### PR DESCRIPTION
We saw a clash in a dry-system provider, which includes `Dry::Configurable`, in which user-supplied code could set a `@config` ivar which suddenly magically became accessible via the `#config` method (instead of the actual dry-configurable config).