### PR TITLE
Allow nested settings to default to `Undefined`

### DIFF
--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -38,7 +38,7 @@ module Dry
         node = [:setting, [name.to_sym, options]]
 
         if block
-          ast << [:nested, [node, DSL.new(&block).ast]]
+          ast << [:nested, [node, DSL.new(**@options, &block).ast]]
         else
           ast << node
         end

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -6,7 +6,7 @@ module Dry
     #
     # @api private
     class DSL
-      VALID_NAME = /\A[a-z_]\w*\z/i.freeze
+      VALID_NAME = /\A[a-z_]\w*\z/i
 
       attr_reader :compiler
 

--- a/spec/integration/dry/configurable/defaults_spec.rb
+++ b/spec/integration/dry/configurable/defaults_spec.rb
@@ -8,11 +8,15 @@ RSpec.describe Dry::Configurable, "default values" do
       setting :foo
       setting :bar, constructor: -> v { v.upcase }
       setting :baz, default: "baz", constructor: -> v { v.upcase }
+      setting :qux do
+        setting :quux
+      end
     end
 
     expect(klass.config.foo).to be(Dry::Configurable::Undefined)
     expect(klass.config.bar).to be(Dry::Configurable::Undefined)
     expect(klass.config.baz).to eq "BAZ"
+    expect(klass.config.qux.quux).to be(Dry::Configurable::Undefined)
 
     klass.configure do |config|
       config.foo = "foo"


### PR DESCRIPTION
I noticed that when using `Dry::Configurable(default_undefined: true)`, nested settings still default to `nil`. This ought to fix that.

And I unfroze a regex at the request of rubocop.