### PR TITLE
Allow multiple includes of Dry::Configurable

### DIFF
--- a/lib/dry/configurable/errors.rb
+++ b/lib/dry/configurable/errors.rb
@@ -5,8 +5,16 @@ module Dry
   #
   # @api public
   module Configurable
+    extend Dry::Core::Deprecations["dry-configurable"]
+
     Error = Class.new(::StandardError)
 
     FrozenConfigError = Class.new(Error)
+
+    AlreadyIncludedError = Class.new(Error)
+    deprecate_constant(
+      :AlreadyIncludedError,
+      message: "`include Dry::Configurable` more than once (if needed)"
+    )
   end
 end

--- a/lib/dry/configurable/errors.rb
+++ b/lib/dry/configurable/errors.rb
@@ -7,7 +7,6 @@ module Dry
   module Configurable
     Error = Class.new(::StandardError)
 
-    AlreadyIncludedError = Class.new(Error)
     FrozenConfigError = Class.new(Error)
   end
 end

--- a/lib/dry/configurable/extension.rb
+++ b/lib/dry/configurable/extension.rb
@@ -35,7 +35,7 @@ module Dry
 
           class << self
             undef :config if method_defined?(:config)
-            undef :configure  if method_defined?(:configure)
+            undef :configure if method_defined?(:configure)
           end
         end
 

--- a/lib/dry/configurable/extension.rb
+++ b/lib/dry/configurable/extension.rb
@@ -26,8 +26,6 @@ module Dry
 
       # @api private
       def included(klass)
-        raise AlreadyIncludedError if klass.include?(InstanceMethods)
-
         super
 
         klass.class_eval do
@@ -36,8 +34,8 @@ module Dry
           prepend(Initializer)
 
           class << self
-            undef :config
-            undef :configure
+            undef :config if method_defined?(:config)
+            undef :configure  if method_defined?(:configure)
           end
         end
 

--- a/spec/integration/dry/configurable/included_spec.rb
+++ b/spec/integration/dry/configurable/included_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Dry::Configurable, ".included" do
     it "allows a subclass to reconfigure the behavior" do
       custom_config_class = Class.new(Dry::Configurable::Config) do
         def db
-          super + "!!"
+          "#{super}!!"
         end
       end
 


### PR DESCRIPTION
Instead of raising AlreadyIncludedError (now removed), update the method undef code in `.included` to handle already-undefined methods gracefully.

Allowing Dry::Configurable to be included multiple times across subclasses now allows for uses cases like a subclass adjusting various extension settings, e.g. `config_class`.