### PR TITLE
Add Config#to_data to allow faster reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ## [Unreleased]
 
+### Added
+
+- Added `Config#to_data`, returning a frozen `Data` representation of the config's resolved values for performance-sensitive read paths (#167 by @cllns)
+
 ### Changed
 
 - Set minimum Ruby version to 3.2 (@alassek)

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -153,6 +153,31 @@ module Dry
         _dry_equalizer_hash
       end
 
+      # Returns a frozen {Data} representation of the config's resolved setting values.
+      #
+      # The Data exposes each setting as a real method, sidestepping the {method_missing}
+      # dispatch on the read path. Intended for performance-sensitive code that reads the same
+      # config repeatedly (e.g. per-request render hot paths). A fresh Data is built per call,
+      # so consumers should memoize the result.
+      #
+      # Only available on a finalized config. Nested configs are converted recursively to nested
+      # Data instances. Values are captured by reference, so in-place mutation of a captured
+      # value remains visible through the Data; finalize with `freeze_values: true` if you want
+      # to prevent that.
+      #
+      # @return [Data]
+      #
+      # @raise [FrozenConfigError] if the config is not yet finalized
+      #
+      # @api public
+      def to_data
+        unless frozen?
+          raise FrozenConfigError, "config must be finalized before #to_data can be called"
+        end
+
+        _settings.data_class.new(**to_data_attrs)
+      end
+
       # @api public
       def finalize!(freeze_values: false)
         return self if frozen?
@@ -181,6 +206,12 @@ module Dry
       end
 
       private
+
+      def to_data_attrs
+        _values.each_with_object({}) do |(name, value), hsh|
+          hsh[name] = value.is_a?(self.class) ? value.to_data : value
+        end
+      end
 
       def method_missing(name, *args)
         setting_name = setting_name_from_method(name)

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -165,6 +165,23 @@ module Dry
       # value remains visible through the Data; finalize with `freeze_values: true` if you want
       # to prevent that.
       #
+      # The returned Data uses Ruby's default structural `==`/`eql?`/`hash`. If you want to use
+      # it as an identity-based cache key (e.g. to skip walking N members on every lookup),
+      # memoize the reference yourself and either:
+      #
+      #   1. key it by `object_id` directly:
+      #
+      #        @cached = view_class.config.to_data
+      #        cache[@cached.object_id] = ...
+      #
+      #   2. use a `compare_by_identity` cache:
+      #
+      #        cache = {}.compare_by_identity
+      #        cache[@cached] = ...
+      #
+      # Either avoids the contract-breaking `hash = object_id` override and keeps Data's
+      # structural equality available for general use.
+      #
       # @return [Data]
       #
       # @raise [FrozenConfigError] if the config is not yet finalized

--- a/lib/dry/configurable/config.rb
+++ b/lib/dry/configurable/config.rb
@@ -153,11 +153,11 @@ module Dry
         _dry_equalizer_hash
       end
 
-      # Returns a frozen {Data} representation of the config's resolved setting values.
+      # Returns a frozen {Data} representation of the config's resolved values.
       #
       # The Data exposes each setting as a real method, sidestepping the {method_missing}
       # dispatch on the read path. Intended for performance-sensitive code that reads the same
-      # config repeatedly (e.g. per-request render hot paths). A fresh Data is built per call,
+      # config repeatedly (e.g. per-request render hot paths). A new object is returned per call,
       # so consumers should memoize the result.
       #
       # Only available on a finalized config. Nested configs are converted recursively to nested

--- a/lib/dry/configurable/dsl.rb
+++ b/lib/dry/configurable/dsl.rb
@@ -8,6 +8,10 @@ module Dry
     class DSL
       VALID_NAME = /\A[a-z_]\w*\z/i
 
+      # Method names defined on `Data` (and its ancestors) that cannot be used as setting
+      # names because `Data.define` would reject them, which would break {Config#to_data}.
+      DATA_RESERVED_NAMES = ::Data.instance_methods.to_set.freeze
+
       attr_reader :compiler
 
       attr_reader :ast
@@ -29,6 +33,12 @@ module Dry
       def setting(name, **options, &block)
         unless VALID_NAME.match?(name.to_s)
           raise ArgumentError, "#{name} is not a valid setting name"
+        end
+
+        if DATA_RESERVED_NAMES.include?(name.to_sym)
+          raise ArgumentError,
+                "#{name.inspect} is not a valid setting name: it conflicts with a Data " \
+                "instance method, which would break Config#to_data"
         end
 
         ensure_valid_options(options)

--- a/lib/dry/configurable/settings.rb
+++ b/lib/dry/configurable/settings.rb
@@ -21,12 +21,24 @@ module Dry
       # @api private
       private def initialize_copy(source)
         @settings = source.settings.dup
+        @data_class = nil
       end
 
       # @api private
       def <<(setting)
+        @data_class = nil
         settings[setting.name] = setting
         self
+      end
+
+      # Returns a {Data} class with one member per defined setting, memoized for the lifetime of
+      # the schema. Invalidated when new settings are added.
+      #
+      # @return [Class]
+      #
+      # @api private
+      def data_class
+        @data_class ||= Data.define(*keys)
       end
 
       # Returns the setting for the given name, if found.

--- a/spec/integration/dry/configurable/config_spec.rb
+++ b/spec/integration/dry/configurable/config_spec.rb
@@ -315,6 +315,78 @@ RSpec.describe Dry::Configurable::Config do
     end
   end
 
+  describe "#to_data" do
+    it "raises if the config is not finalized" do
+      klass.setting :db
+
+      expect { klass.config.to_data }.to raise_error(
+        Dry::Configurable::FrozenConfigError,
+        /must be finalized/
+      )
+    end
+
+    it "returns a frozen Data instance with a member for every setting" do
+      klass.setting :db, default: "sqlite"
+      klass.setting :pool, default: 5
+      klass.finalize!
+
+      data = klass.config.to_data
+
+      expect(data).to be_frozen
+      expect(data).to be_a(Data)
+      expect(data.db).to eq("sqlite")
+      expect(data.pool).to eq(5)
+      expect(data.members).to eq(%i[db pool])
+    end
+
+    it "converts nested configs recursively as Data instances" do
+      klass.setting :db do
+        setting :host, default: "localhost"
+        setting :port, default: 5432
+      end
+      klass.finalize!
+
+      data = klass.config.to_data
+
+      expect(data.db).to be_a(Data)
+      expect(data.db).to be_frozen
+      expect(data.db.host).to eq("localhost")
+      expect(data.db.port).to eq(5432)
+    end
+
+    it "returns a fresh but structurally-equal instance per call" do
+      klass.setting :db, default: "sqlite"
+      klass.finalize!
+
+      first = klass.config.to_data
+      second = klass.config.to_data
+
+      expect(first).not_to equal(second)
+      expect(first).to eq(second)
+      expect(first).to eql(second)
+      expect(first.hash).to eq(second.hash)
+    end
+
+    it "shares the underlying Data class across configs with the same schema" do
+      klass.setting :db
+      klass.setting :pool
+
+      first = klass.config.dup.finalize!
+      second = klass.config.dup.finalize!
+
+      expect(first.to_data.class).to equal(second.to_data.class)
+    end
+
+    it "captures mutable values by reference (not deep-frozen by default)" do
+      klass.setting :list, default: []
+      klass.finalize!
+
+      klass.config.list << "added after finalize"
+
+      expect(klass.config.to_data.list).to eq(["added after finalize"])
+    end
+  end
+
   describe "#method_missing" do
     it "provides access to reader methods" do
       klass.setting :hello

--- a/spec/unit/dry/configurable/dsl_spec.rb
+++ b/spec/unit/dry/configurable/dsl_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe Dry::Configurable::DSL do
     expect(setting.constructor.("sqlite")).to eq("jdbc:sqlite")
   end
 
+  it "rejects setting names that conflict with Data instance methods" do
+    expect { dsl.setting :hash }.to raise_error(
+      ArgumentError,
+      /:hash is not a valid setting name.*Data instance method.*Config#to_data/
+    )
+
+    expect { dsl.setting :members }.to raise_error(
+      ArgumentError,
+      /:members is not a valid setting name/
+    )
+
+    expect { dsl.setting :class }.to raise_error(
+      ArgumentError,
+      /:class is not a valid setting name/
+    )
+  end
+
   it "compiles a nested list of settings" do
     setting =
       dsl.setting(:db) do


### PR DESCRIPTION
I explored doing this upstream in https://github.com/hanami/hanami-view/pull/276 but this is something we can, and should, add to dry-configurable.

This is similar to adding `reader: true` but that adds an attr_reader on the host itself, not the config. This returns a new `Data` object wrapping the settings (after finalize).

You have to cache it by object_id (or using Hash#cache_by_identity) in order to get all the benefits of it, in a library like hanami-view where classes are meant to be instantiated once and the instances re-used.

| Pattern | ns/op | vs `config.foo` |
|---|---:|---:|
| `cached.foo` (memoized `to_data`) | 38 | **13.6× faster** |
| `config.foo` (existing, method_missing) | 517 | 1× (baseline) |
| `config.to_data.foo` (fresh per call) | 838 | 1.6× slower |
